### PR TITLE
Test sitthipongdev

### DIFF
--- a/Src/agent_core/llm/client.py
+++ b/Src/agent_core/llm/client.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import math
 import os
+import time
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Any, Optional
 
 # ---------------------------------------------------------------------------
 # Data Model
@@ -14,9 +16,24 @@ from typing import Optional
 class PromptPackage:
     """ข้อมูล prompt ที่ใช้ร่วมกันทุก provider"""
 
-    system: str  # System instructions
-    user: str  # User message
-    step_label: str  # Label ของ step เช่น "THOUGHT_1", "THOUGHT_FINAL"
+    system: str
+    user: str
+    step_label: str
+
+
+@dataclass
+class LLMCallResult:
+    """ผลลัพธ์การเรียก LLM พร้อม usage metadata"""
+
+    text: str
+    provider: str
+    model: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    latency_ms: float = 0.0
+    step_label: str = ""
+    raw_usage: dict[str, Any] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -52,9 +69,12 @@ class LLMClient(ABC):
     Abstract base class สำหรับ LLM provider ทุกตัว
 
     Contract:
-    - call()         → รับ PromptPackage, คืน str (JSON expected)
-    - is_available() → ตรวจสอบว่า client พร้อมใช้งาน
+    - call()               → รับ PromptPackage, คืน str (JSON expected)
+    - call_with_metadata() → คืนข้อความพร้อม usage metadata
+    - is_available()       → ตรวจสอบว่า client พร้อมใช้งาน
     """
+
+    PROVIDER_NAME = "unknown"
 
     @abstractmethod
     def call(self, prompt_package: PromptPackage) -> str:
@@ -83,12 +103,108 @@ class LLMClient(ABC):
         """
         ...
 
+    def call_with_metadata(self, prompt_package: PromptPackage) -> LLMCallResult:
+        """
+        Default implementation สำหรับ provider ที่ยังไม่มี usage จาก SDK
+        จะ fallback เป็นการ estimate token จากความยาวข้อความ
+        """
+        started_at = time.perf_counter()
+        text = self.call(prompt_package)
+        latency_ms = (time.perf_counter() - started_at) * 1000
+
+        prompt_tokens = self._estimate_tokens(
+            f"{prompt_package.system}\n\n{prompt_package.user}"
+        )
+        completion_tokens = self._estimate_tokens(text)
+
+        return LLMCallResult(
+            text=text,
+            provider=self.provider_name,
+            model=self.model_name,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+            latency_ms=round(latency_ms, 2),
+            step_label=prompt_package.step_label,
+            raw_usage={"source": "estimated"},
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return getattr(self, "PROVIDER_NAME", self.__class__.__name__.lower())
+
+    @property
+    def model_name(self) -> str:
+        return str(getattr(self, "model", self.__class__.__name__))
+
+    def _build_result(
+        self,
+        prompt_package: PromptPackage,
+        text: str,
+        latency_ms: float,
+        prompt_tokens: int = 0,
+        completion_tokens: int = 0,
+        total_tokens: int = 0,
+        raw_usage: Optional[dict[str, Any]] = None,
+    ) -> LLMCallResult:
+        if total_tokens <= 0:
+            total_tokens = prompt_tokens + completion_tokens
+
+        return LLMCallResult(
+            text=text,
+            provider=self.provider_name,
+            model=self.model_name,
+            prompt_tokens=max(0, prompt_tokens),
+            completion_tokens=max(0, completion_tokens),
+            total_tokens=max(0, total_tokens),
+            latency_ms=round(latency_ms, 2),
+            step_label=prompt_package.step_label,
+            raw_usage=raw_usage or {},
+        )
+
+    @staticmethod
+    def _estimate_tokens(text: str) -> int:
+        if not text:
+            return 0
+        return max(1, math.ceil(len(text) / 4))
+
+    @staticmethod
+    def _safe_int(value: Any) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @classmethod
+    def _safe_usage_dict(cls, usage: Any) -> dict[str, Any]:
+        if usage is None:
+            return {}
+        if isinstance(usage, dict):
+            return dict(usage)
+        if hasattr(usage, "model_dump"):
+            return usage.model_dump()
+        if hasattr(usage, "to_dict"):
+            return usage.to_dict()
+
+        data: dict[str, Any] = {}
+        for name in dir(usage):
+            if name.startswith("_"):
+                continue
+            value = getattr(usage, name, None)
+            if callable(value):
+                continue
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                data[name] = value
+        return data
+
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} available={self.is_available()}>"
+
 
 # ---------------------------------------------------------------------------
 # Default mock responses
 # ---------------------------------------------------------------------------
+
 
 DEFAULT_MOCK_RESPONSES: dict[str, str] = {
     "THOUGHT_1": '{"action": "CALL_TOOL", "tool": "get_news", "params": {}}',
@@ -96,6 +212,7 @@ DEFAULT_MOCK_RESPONSES: dict[str, str] = {
     "THOUGHT_3": '{"action": "FINAL_DECISION", "signal": "HOLD", "confidence": 0.6, "rationale": "Insufficient signal"}',
     "THOUGHT_FINAL": '{"action": "FINAL_DECISION", "signal": "HOLD", "confidence": 0.5, "rationale": "Mock final decision"}',
 }
+
 
 # ---------------------------------------------------------------------------
 # Mock LLM Client
@@ -124,6 +241,21 @@ class MockClient(LLMClient):
         return self.response_map.get(
             prompt_package.step_label,
             '{"action": "FINAL_DECISION", "signal": "HOLD", "confidence": 0.5, "rationale": "Mock fallback"}',
+        )
+
+    def call_with_metadata(self, prompt_package: PromptPackage) -> LLMCallResult:
+        text = self.call(prompt_package)
+        prompt_tokens = self._estimate_tokens(
+            f"{prompt_package.system}\n\n{prompt_package.user}"
+        )
+        completion_tokens = self._estimate_tokens(text)
+        return self._build_result(
+            prompt_package=prompt_package,
+            text=text,
+            latency_ms=0.0,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            raw_usage={"source": "mock-estimated"},
         )
 
     def is_available(self) -> bool:
@@ -170,16 +302,35 @@ class GeminiClient(LLMClient):
                 )
 
     def call(self, prompt_package: PromptPackage) -> str:
+        return self.call_with_metadata(prompt_package).text
+
+    def call_with_metadata(self, prompt_package: PromptPackage) -> LLMCallResult:
         if self.use_mock:
-            return self._mock_response(prompt_package)
+            text = DEFAULT_MOCK_RESPONSES.get(
+                prompt_package.step_label,
+                '{"action": "FINAL_DECISION", "signal": "HOLD", "confidence": 0.5, "rationale": "Mock fallback"}',
+            )
+            return self._build_result(
+                prompt_package=prompt_package,
+                text=text,
+                latency_ms=0.0,
+                prompt_tokens=self._estimate_tokens(
+                    f"{prompt_package.system}\n\n{prompt_package.user}"
+                ),
+                completion_tokens=self._estimate_tokens(text),
+                raw_usage={"source": "gemini-mock-estimated"},
+            )
 
         if not self._client:
             raise LLMUnavailableError("GeminiClient is not initialized.")
 
+        full_prompt = (
+            f"SYSTEM:\n{prompt_package.system}\n\n"
+            f"USER:\n{prompt_package.user}"
+        )
+
+        started_at = time.perf_counter()
         try:
-            full_prompt = (
-                f"SYSTEM:\n{prompt_package.system}\n\n" f"USER:\n{prompt_package.user}"
-            )
             response = self._client.models.generate_content(
                 model=self.model,
                 contents=full_prompt,
@@ -187,8 +338,27 @@ class GeminiClient(LLMClient):
             return response.text
         except Exception as e:
             raise LLMProviderError(
-                f"Gemini API error at {prompt_package.step_label}: {e}"
-            ) from e
+                f"Gemini API error at {prompt_package.step_label}: {exc}"
+            ) from exc
+
+        latency_ms = (time.perf_counter() - started_at) * 1000
+        text = getattr(response, "text", "") or ""
+        usage = getattr(response, "usage_metadata", None)
+        prompt_tokens = self._safe_int(getattr(usage, "prompt_token_count", 0))
+        completion_tokens = self._safe_int(
+            getattr(usage, "candidates_token_count", 0)
+        )
+        total_tokens = self._safe_int(getattr(usage, "total_token_count", 0))
+
+        return self._build_result(
+            prompt_package=prompt_package,
+            text=text,
+            latency_ms=latency_ms,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            raw_usage=self._safe_usage_dict(usage),
+        )
 
     def is_available(self) -> bool:
         if self.use_mock:
@@ -218,6 +388,7 @@ class OpenAIClient(LLMClient):
 
         try:
             from openai import OpenAI  # type: ignore
+
             self._client = OpenAI(api_key=api_key or os.environ["OPENAI_API_KEY"])
         except KeyError:
             raise LLMUnavailableError(
@@ -238,9 +409,26 @@ class OpenAIClient(LLMClient):
                     {"role": "user", "content": prompt_package.user},
                 ],
             )
-            return response.choices[0].message.content
-        except Exception as e:
-            raise LLMProviderError(f"OpenAI API error at {prompt_package.step_label}: {e}") from e
+        except Exception as exc:
+            raise LLMProviderError(
+                f"OpenAI API error at {prompt_package.step_label}: {exc}"
+            ) from exc
+
+        latency_ms = (time.perf_counter() - started_at) * 1000
+        text = response.choices[0].message.content or ""
+        usage = getattr(response, "usage", None)
+
+        return self._build_result(
+            prompt_package=prompt_package,
+            text=text,
+            latency_ms=latency_ms,
+            prompt_tokens=self._safe_int(getattr(usage, "prompt_tokens", 0)),
+            completion_tokens=self._safe_int(
+                getattr(usage, "completion_tokens", 0)
+            ),
+            total_tokens=self._safe_int(getattr(usage, "total_tokens", 0)),
+            raw_usage=self._safe_usage_dict(usage),
+        )
 
     def is_available(self) -> bool:
         return self._client is not None
@@ -262,6 +450,7 @@ class ClaudeClient(LLMClient):
 
         try:
             from anthropic import Anthropic  # type: ignore
+
             self._client = Anthropic(api_key=api_key or os.environ["ANTHROPIC_API_KEY"])
         except KeyError:
             raise LLMUnavailableError(
@@ -273,22 +462,42 @@ class ClaudeClient(LLMClient):
             )
 
     def call(self, prompt_package: PromptPackage) -> str:
+        return self.call_with_metadata(prompt_package).text
+
+    def call_with_metadata(self, prompt_package: PromptPackage) -> LLMCallResult:
+        started_at = time.perf_counter()
         try:
             response = self._client.messages.create(
                 model=self.model,
                 max_tokens=self.max_tokens,
                 system=prompt_package.system,
-                messages=[
-                    {"role": "user", "content": prompt_package.user},
-                ],
+                messages=[{"role": "user", "content": prompt_package.user}],
             )
-            return response.content[0].text
-        except Exception as e:
-            raise LLMProviderError(f"Claude API error at {prompt_package.step_label}: {e}") from e
+        except Exception as exc:
+            raise LLMProviderError(
+                f"Claude API error at {prompt_package.step_label}: {exc}"
+            ) from exc
+
+        latency_ms = (time.perf_counter() - started_at) * 1000
+        text = response.content[0].text if response.content else ""
+        usage = getattr(response, "usage", None)
+        prompt_tokens = self._safe_int(getattr(usage, "input_tokens", 0))
+        completion_tokens = self._safe_int(getattr(usage, "output_tokens", 0))
+
+        return self._build_result(
+            prompt_package=prompt_package,
+            text=text,
+            latency_ms=latency_ms,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+            raw_usage=self._safe_usage_dict(usage),
+        )
 
     def is_available(self) -> bool:
         return self._client is not None
-    
+
+
 class GroqClient(LLMClient):
     """LLM Client สำหรับ Groq (LPU Inference Engine) - เน้นความเร็วสูง"""
 
@@ -306,15 +515,22 @@ class GroqClient(LLMClient):
 
         try:
             from groq import Groq  # type: ignore
+
             self._client = Groq(api_key=api_key or os.environ["GROQ_API_KEY"])
         except KeyError:
             raise LLMUnavailableError("GROQ_API_KEY not found in env.")
         except ImportError:
-            raise LLMUnavailableError("groq package not installed. Run: pip install groq")
+            raise LLMUnavailableError(
+                "groq package not installed. Run: pip install groq"
+            )
 
     def call(self, prompt_package: PromptPackage) -> str:
+        return self.call_with_metadata(prompt_package).text
+
+    def call_with_metadata(self, prompt_package: PromptPackage) -> LLMCallResult:
+        started_at = time.perf_counter()
         try:
-            chat_completion = self._client.chat.completions.create(
+            response = self._client.chat.completions.create(
                 messages=[
                     {"role": "system", "content": prompt_package.system},
                     {"role": "user", "content": prompt_package.user},
@@ -322,13 +538,29 @@ class GroqClient(LLMClient):
                 model=self.model,
                 temperature=self.temperature,
             )
-            return chat_completion.choices[0].message.content
-        except Exception as e:
-            raise LLMProviderError(f"Groq API error: {e}") from e
+        except Exception as exc:
+            raise LLMProviderError(f"Groq API error: {exc}") from exc
+
+        latency_ms = (time.perf_counter() - started_at) * 1000
+        text = response.choices[0].message.content or ""
+        usage = getattr(response, "usage", None)
+
+        return self._build_result(
+            prompt_package=prompt_package,
+            text=text,
+            latency_ms=latency_ms,
+            prompt_tokens=self._safe_int(getattr(usage, "prompt_tokens", 0)),
+            completion_tokens=self._safe_int(
+                getattr(usage, "completion_tokens", 0)
+            ),
+            total_tokens=self._safe_int(getattr(usage, "total_tokens", 0)),
+            raw_usage=self._safe_usage_dict(usage),
+        )
 
     def is_available(self) -> bool:
         return self._client is not None
-    
+
+
 class DeepSeekClient(LLMClient):
     """LLM Client สำหรับ DeepSeek API - รองรับ OpenAI compatible format"""
 
@@ -356,6 +588,10 @@ class DeepSeekClient(LLMClient):
             raise LLMUnavailableError("openai package missing.")
 
     def call(self, prompt_package: PromptPackage) -> str:
+        return self.call_with_metadata(prompt_package).text
+
+    def call_with_metadata(self, prompt_package: PromptPackage) -> LLMCallResult:
+        started_at = time.perf_counter()
         try:
             response = self._client.chat.completions.create(
                 model=self.model,
@@ -366,18 +602,33 @@ class DeepSeekClient(LLMClient):
                 temperature=self.temperature,
                 stream=False
             )
-            return response.choices[0].message.content
-        except Exception as e:
-            raise LLMProviderError(f"DeepSeek API error: {e}") from e
+        except Exception as exc:
+            raise LLMProviderError(f"DeepSeek API error: {exc}") from exc
+
+        latency_ms = (time.perf_counter() - started_at) * 1000
+        text = response.choices[0].message.content or ""
+        usage = getattr(response, "usage", None)
+
+        return self._build_result(
+            prompt_package=prompt_package,
+            text=text,
+            latency_ms=latency_ms,
+            prompt_tokens=self._safe_int(getattr(usage, "prompt_tokens", 0)),
+            completion_tokens=self._safe_int(
+                getattr(usage, "completion_tokens", 0)
+            ),
+            total_tokens=self._safe_int(getattr(usage, "total_tokens", 0)),
+            raw_usage=self._safe_usage_dict(usage),
+        )
 
     def is_available(self) -> bool:
         return self._client is not None
 
 
-
 # ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
+
 
 class LLMClientFactory:
     """
@@ -395,10 +646,9 @@ class LLMClientFactory:
         "gemini": GeminiClient,
         "openai": OpenAIClient,
         "claude": ClaudeClient,
-        "mock":   MockClient,
+        "mock": MockClient,
         "groq": GroqClient,
         "deepseek": DeepSeekClient,
-
     }
 
     @classmethod

--- a/Src/agent_core/llm/test_client.py
+++ b/Src/agent_core/llm/test_client.py
@@ -20,8 +20,13 @@ def test_provider(name: str, **kwargs):
         available = client.is_available()
         print(f"  available: {available}")
 
-        response = client.call(TEST_PROMPT)
-        print(f"  response: {response[:120]}")
+        response = client.call_with_metadata(TEST_PROMPT)
+        print(f"  response: {response.text[:120]}")
+        print(
+            f"  usage   : prompt={response.prompt_tokens} "
+            f"completion={response.completion_tokens} total={response.total_tokens} "
+            f"latency={response.latency_ms:.2f}ms"
+        )
         print(f"  PASS")
     except Exception as e:
         print(f"  FAIL -> {type(e).__name__}: {e}")

--- a/Src/backtest/__init__.py
+++ b/Src/backtest/__init__.py
@@ -11,6 +11,7 @@ from backtest.portfolio_engine import (
 )
 from backtest.prepare_backtest_data import load_and_merge, create_walk_forward_windows
 from backtest.logger import BacktestLogger
+from backtest.llm_signal_generator import LLMBacktestSignalGenerator, UsageSummary
 
 __all__ = [
     "PortfolioBacktestEngine",
@@ -20,4 +21,6 @@ __all__ = [
     "load_and_merge",
     "create_walk_forward_windows",
     "BacktestLogger",
+    "LLMBacktestSignalGenerator",
+    "UsageSummary",
 ]

--- a/Src/backtest/llm_backtest_runner.py
+++ b/Src/backtest/llm_backtest_runner.py
@@ -1,0 +1,296 @@
+"""
+backtest/llm_backtest_runner.py
+รัน Portfolio Backtest Engine โดยสร้างสัญญาณจาก LLM จริงหรือ mock
+
+Examples (run from Src/):
+    python -m backtest.llm_backtest_runner --providers gemini groq
+    python -m backtest.llm_backtest_runner --providers gemini --use-mock
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+src_dir = os.path.dirname(current_dir)
+sys.path.insert(0, src_dir)
+
+from backtest.llm_signal_generator import LLMBacktestSignalGenerator, UsageSummary
+from backtest.portfolio_engine import PortfolioBacktestEngine, PortfolioSignal
+from backtest.prepare_backtest_data import create_walk_forward_windows, load_and_merge
+
+
+def generate_hold_signals(dates: list[str], model_name: str, reason: str) -> list[PortfolioSignal]:
+    return [
+        PortfolioSignal(
+            date=date_str,
+            signal="HOLD",
+            confidence=0.0,
+            model_name=model_name,
+            rationale=reason,
+        )
+        for date_str in dates
+    ]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="LLM portfolio backtest runner")
+    parser.add_argument(
+        "--providers",
+        nargs="+",
+        default=["gemini", "groq"],
+        help="รายชื่อ provider ที่จะทดสอบ",
+    )
+    parser.add_argument(
+        "--lookback-bars",
+        type=int,
+        default=10,
+        help="จำนวนแท่งย้อนหลังที่ส่งให้ LLM เห็นต่อวัน",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.2,
+        help="temperature สำหรับ provider ที่รองรับ",
+    )
+    parser.add_argument(
+        "--use-mock",
+        action="store_true",
+        help="ใช้ mock mode สำหรับ Gemini แทน API จริง",
+    )
+    parser.add_argument(
+        "--model-override",
+        action="append",
+        default=[],
+        help="override model เป็นรูปแบบ provider=model เช่น gemini=gemini-2.5-flash-lite",
+    )
+    return parser.parse_args()
+
+
+def parse_model_overrides(items: list[str]) -> dict[str, str]:
+    overrides = {}
+    for item in items:
+        if "=" not in item:
+            raise ValueError(f"Invalid model override: {item!r}. Expected provider=model")
+        provider, model = item.split("=", 1)
+        overrides[provider.strip().lower()] = model.strip()
+    return overrides
+
+
+def build_signals(
+    model_name: str,
+    train_data,
+    test_data,
+    model_overrides: dict[str, str],
+    lookback_bars: int,
+    temperature: float,
+    use_mock: bool,
+) -> tuple[list[PortfolioSignal], UsageSummary]:
+    dates = [d.strftime("%Y-%m-%d") for d in test_data["date"]]
+
+    try:
+        generator = LLMBacktestSignalGenerator(
+            provider=model_name,
+            model=model_overrides.get(model_name),
+            temperature=temperature,
+            lookback_bars=lookback_bars,
+            use_mock=use_mock,
+        )
+        return generator.generate_signals(train_data=train_data, test_data=test_data)
+    except Exception as exc:
+        usage = UsageSummary(
+            provider=model_name,
+            model=model_overrides.get(model_name, model_name),
+            total_calls=len(dates),
+            failed_calls=len(dates),
+            last_error=str(exc),
+        )
+        return (
+            generate_hold_signals(dates, model_name, f"LLM unavailable: {exc}"),
+            usage,
+        )
+
+
+def main() -> None:
+    args = parse_args()
+    model_overrides = parse_model_overrides(args.model_override)
+
+    print("Loading data...")
+    df = load_and_merge()
+
+    header_lines = []
+    header_lines.append(f"Data loaded: {len(df)} bars (XAUUSD + USDTHB merged)")
+    header_lines.append(
+        f"Date range: {df['date'].iloc[0].date()} -> {df['date'].iloc[-1].date()}"
+    )
+    header_lines.append(
+        f"Price range: {df['price_per_gram'].min():.2f} -> {df['price_per_gram'].max():.2f} THB/gram"
+    )
+    header_lines.append("Signal source: llm")
+    header_lines.append(f"Providers: {', '.join(args.providers)}")
+    header_lines.append("")
+
+    windows = create_walk_forward_windows(df)
+    header_lines.append(f"Walk-forward windows: {len(windows)}")
+    header_lines.append("")
+
+    engine = PortfolioBacktestEngine(
+        initial_capital=1500.0,
+        spread_pct=0.003,
+        min_trade_thb=1000.0,
+        force_liquidation=True,
+    )
+    header_lines.append("Engine config:")
+    header_lines.append(f"  Initial capital  : {engine.initial_capital:.2f} THB")
+    header_lines.append(f"  Spread           : {engine.spread_pct * 100:.1f}%")
+    header_lines.append(f"  Min trade        : {engine.min_trade_thb:.2f} THB")
+    header_lines.append(f"  Force liquidation: {engine.force_liquidation}")
+    header_lines.append("")
+
+    all_rows: list[dict] = []
+    model_logs = {provider: list(header_lines) for provider in args.providers}
+
+    for window in windows:
+        year = window["year"]
+        month = window["month"]
+        quarter = window["quarter"]
+        train_data = window["train_data"]
+        test_data = window["test_data"]
+
+        window_header = []
+        window_header.append("=" * 78)
+        window_header.append(f"  WALK-FORWARD WINDOW: {quarter} {year} (Month {month})")
+        window_header.append(
+            f"  Train: {window['train_start']} -> {window['train_end']} ({window['train_bars']} bars)"
+        )
+        window_header.append(
+            f"  Test:  {window['test_start']} -> {window['test_end']} ({window['test_bars']} bars)"
+        )
+        window_header.append("=" * 78)
+        window_header.append("")
+
+        for model_name in args.providers:
+            model_logs[model_name].extend(window_header)
+            signals, usage = build_signals(
+                model_name=model_name,
+                train_data=train_data,
+                test_data=test_data,
+                model_overrides=model_overrides,
+                lookback_bars=args.lookback_bars,
+                temperature=args.temperature,
+                use_mock=args.use_mock,
+            )
+
+            summary = engine.run(
+                price_data=test_data,
+                signals=signals,
+                model_name=model_name,
+                window_year=year,
+            )
+
+            row = {
+                "model_name": model_name,
+                "quarter": quarter,
+                "window_year": year,
+                "final_value": summary.final_value,
+                "total_return_pct": summary.total_return_pct,
+                "max_drawdown_thb": summary.max_drawdown_thb,
+                "sharpe_ratio": summary.sharpe_ratio,
+                "vc_return": summary.vc_settlement["return_to_vc"],
+                "usage": usage.to_dict(),
+            }
+            all_rows.append(row)
+
+            ml = model_logs[model_name]
+            ml.append(f"  --- {model_name} ---")
+            ml.append(f"  Initial Capital : {summary.initial_capital:.2f} THB")
+            ml.append(f"  Final Value     : {summary.final_value:.2f} THB")
+            ml.append(
+                f"  Return          : {summary.total_return_thb:+.2f} THB ({summary.total_return_pct:+.2f}%)"
+            )
+            ml.append(
+                f"  Trades          : {summary.total_trades} (Buy={summary.buy_count}, Sell={summary.sell_count})"
+            )
+            ml.append(
+                f"  Hold/Rejected   : {summary.hold_count} / {summary.rejected_count}"
+            )
+            ml.append(
+                f"  Max Drawdown    : {summary.max_drawdown_thb:.2f} THB ({summary.max_drawdown_pct:.2f}%)"
+            )
+            ml.append(f"  Sharpe Ratio    : {summary.sharpe_ratio:.4f}")
+            ml.append(f"  Spread Cost     : {summary.spread_cost_total:.2f} THB")
+            ml.append("  Usage Summary:")
+            ml.append(f"    Provider      : {usage.provider}")
+            ml.append(f"    Model         : {usage.model}")
+            ml.append(f"    Calls         : {usage.total_calls}")
+            ml.append(
+                f"    Success/Fail  : {usage.successful_calls} / {usage.failed_calls}"
+            )
+            ml.append(f"    Prompt tokens : {usage.prompt_tokens}")
+            ml.append(f"    Output tokens : {usage.completion_tokens}")
+            ml.append(f"    Total tokens  : {usage.total_tokens}")
+            ml.append(f"    Input cost    : ${usage.input_cost_usd:.6f}")
+            ml.append(f"    Output cost   : ${usage.output_cost_usd:.6f}")
+            ml.append(f"    Total cost    : ${usage.total_cost_usd:.6f}")
+            ml.append(f"    Avg latency   : {usage.avg_latency_ms:.2f} ms")
+            if usage.pricing_source:
+                ml.append(f"    Pricing src   : {usage.pricing_source}")
+            elif usage.total_tokens > 0:
+                ml.append("    Pricing src   : unavailable for this model")
+            if usage.last_error:
+                ml.append(f"    Last error    : {usage.last_error}")
+            ml.append("")
+
+    summary_lines = list(header_lines)
+    summary_lines.append("=" * 148)
+    summary_lines.append("  WALK-FORWARD COMPARISON")
+    summary_lines.append("=" * 148)
+    header = (
+        f"{'Model':<10} {'Q/Year':>8} {'Final':>10} {'Return(%)':>10} "
+        f"{'MaxDD':>10} {'Sharpe':>8} {'Calls':>7} {'Tokens':>12} "
+        f"{'Cost(USD)':>10} {'AvgLat(ms)':>11} {'VC Return':>10}"
+    )
+    summary_lines.append(header)
+    summary_lines.append("-" * len(header))
+
+    for row in all_rows:
+        usage = row["usage"]
+        q_year = f"{row['quarter']}/{row['window_year']}"
+        summary_lines.append(
+            f"{row['model_name']:<10} {q_year:>8} "
+            f"{row['final_value']:>10.2f} "
+            f"{row['total_return_pct']:>+8.2f}% "
+            f"{row['max_drawdown_thb']:>10.2f} "
+            f"{row['sharpe_ratio']:>8.4f} "
+            f"{usage['total_calls']:>7} "
+            f"{usage['total_tokens']:>12} "
+            f"{usage['total_cost_usd']:>10.6f} "
+            f"{usage['avg_latency_ms']:>11.2f} "
+            f"{row['vc_return']:>10.2f}"
+        )
+        if usage["last_error"]:
+            summary_lines.append(f"  note: {row['model_name']} -> {usage['last_error']}")
+        elif usage["total_tokens"] > 0 and not usage["pricing_available"]:
+            summary_lines.append(
+                f"  note: {row['model_name']} -> pricing unavailable for model {usage['model']}"
+            )
+    summary_lines.append("=" * 148)
+    summary_lines.append("")
+    summary_lines.append("BACKTEST RUN COMPLETE")
+
+    for model_name in args.providers:
+        model_file = os.path.join(current_dir, f"llm_backtest_result_{model_name}.txt")
+        with open(model_file, "w", encoding="utf-8") as f:
+            f.write("\n".join(model_logs[model_name]))
+        print(f"Model log saved: {model_file}")
+
+    summary_file = os.path.join(current_dir, "llm_backtest_result_summary.txt")
+    with open(summary_file, "w", encoding="utf-8") as f:
+        f.write("\n".join(summary_lines))
+    print(f"\nSummary log saved: {summary_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Src/backtest/llm_pricing.py
+++ b/Src/backtest/llm_pricing.py
@@ -1,0 +1,234 @@
+"""
+backtest/llm_pricing.py
+ราคา token แบบง่ายสำหรับคำนวณต้นทุน backtest เป็น USD
+อ้างอิงราคาจากหน้า pricing/model docs ทางการของแต่ละ provider
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TokenPricing:
+    provider: str
+    model_match: str
+    input_per_million_usd: float
+    output_per_million_usd: float
+    source_url: str
+
+
+@dataclass(frozen=True)
+class TokenCostEstimate:
+    provider: str
+    model: str
+    pricing: TokenPricing | None
+    prompt_tokens: int
+    completion_tokens: int
+
+    @property
+    def input_cost_usd(self) -> float:
+        if not self.pricing:
+            return 0.0
+        return round(
+            (self.prompt_tokens / 1_000_000) * self.pricing.input_per_million_usd,
+            6,
+        )
+
+    @property
+    def output_cost_usd(self) -> float:
+        if not self.pricing:
+            return 0.0
+        return round(
+            (self.completion_tokens / 1_000_000) * self.pricing.output_per_million_usd,
+            6,
+        )
+
+    @property
+    def total_cost_usd(self) -> float:
+        return round(self.input_cost_usd + self.output_cost_usd, 6)
+
+
+_PRICING_RULES: dict[str, list[TokenPricing]] = {
+    "gemini": [
+        TokenPricing(
+            provider="gemini",
+            model_match="gemini-2.5-flash-lite-preview-09-2025",
+            input_per_million_usd=0.10,
+            output_per_million_usd=0.40,
+            source_url="https://ai.google.dev/gemini-api/docs/pricing",
+        ),
+        TokenPricing(
+            provider="gemini",
+            model_match="gemini-2.5-flash-lite",
+            input_per_million_usd=0.10,
+            output_per_million_usd=0.40,
+            source_url="https://ai.google.dev/gemini-api/docs/pricing",
+        ),
+        TokenPricing(
+            provider="gemini",
+            model_match="gemini-2.5-flash",
+            input_per_million_usd=0.30,
+            output_per_million_usd=2.50,
+            source_url="https://ai.google.dev/gemini-api/docs/pricing",
+        ),
+        TokenPricing(
+            provider="gemini",
+            model_match="gemini-2.0-flash-lite",
+            input_per_million_usd=0.075,
+            output_per_million_usd=0.30,
+            source_url="https://ai.google.dev/gemini-api/docs/pricing",
+        ),
+        TokenPricing(
+            provider="gemini",
+            model_match="gemini-2.0-flash",
+            input_per_million_usd=0.10,
+            output_per_million_usd=0.40,
+            source_url="https://ai.google.dev/gemini-api/docs/pricing",
+        ),
+    ],
+    "groq": [
+        TokenPricing(
+            provider="groq",
+            model_match="openai/gpt-oss-20b",
+            input_per_million_usd=0.075,
+            output_per_million_usd=0.30,
+            source_url="https://console.groq.com/docs/model/openai/gpt-oss-20b",
+        ),
+        TokenPricing(
+            provider="groq",
+            model_match="openai/gpt-oss-120b",
+            input_per_million_usd=0.15,
+            output_per_million_usd=0.60,
+            source_url="https://console.groq.com/docs/models",
+        ),
+        TokenPricing(
+            provider="groq",
+            model_match="meta-llama/llama-4-scout-17b-16e-instruct",
+            input_per_million_usd=0.11,
+            output_per_million_usd=0.34,
+            source_url="https://console.groq.com/docs/model/llama-4-scout-17b-16e-instruct",
+        ),
+        TokenPricing(
+            provider="groq",
+            model_match="llama-3.3-70b-specdec",
+            input_per_million_usd=0.59,
+            output_per_million_usd=0.99,
+            source_url="https://console.groq.com/docs/model/llama-3.3-70b-specdec",
+        ),
+        TokenPricing(
+            provider="groq",
+            model_match="llama-3.3-70b-versatile",
+            input_per_million_usd=0.59,
+            output_per_million_usd=0.79,
+            source_url="https://console.groq.com/docs/model/llama-3.3-70b-versatile",
+        ),
+    ],
+    "openai": [
+        TokenPricing(
+            provider="openai",
+            model_match="gpt-4o-mini",
+            input_per_million_usd=0.15,
+            output_per_million_usd=0.60,
+            source_url="https://developers.openai.com/api/docs/models/gpt-4o-mini",
+        ),
+        TokenPricing(
+            provider="openai",
+            model_match="gpt-4o",
+            input_per_million_usd=2.50,
+            output_per_million_usd=10.00,
+            source_url="https://developers.openai.com/api/docs/models/gpt-4o",
+        ),
+        TokenPricing(
+            provider="openai",
+            model_match="gpt-5-mini",
+            input_per_million_usd=0.25,
+            output_per_million_usd=2.00,
+            source_url="https://openai.com/api/pricing/",
+        ),
+        TokenPricing(
+            provider="openai",
+            model_match="gpt-5",
+            input_per_million_usd=2.50,
+            output_per_million_usd=15.00,
+            source_url="https://openai.com/api/pricing/",
+        ),
+    ],
+    "claude": [
+        TokenPricing(
+            provider="claude",
+            model_match="claude-opus-4-1",
+            input_per_million_usd=15.00,
+            output_per_million_usd=75.00,
+            source_url="https://www.anthropic.com/pricing",
+        ),
+        TokenPricing(
+            provider="claude",
+            model_match="claude-opus-4.1",
+            input_per_million_usd=15.00,
+            output_per_million_usd=75.00,
+            source_url="https://www.anthropic.com/pricing",
+        ),
+        TokenPricing(
+            provider="claude",
+            model_match="claude-sonnet-4",
+            input_per_million_usd=3.00,
+            output_per_million_usd=15.00,
+            source_url="https://www.anthropic.com/pricing",
+        ),
+        TokenPricing(
+            provider="claude",
+            model_match="claude-3-5-haiku",
+            input_per_million_usd=0.80,
+            output_per_million_usd=4.00,
+            source_url="https://www.anthropic.com/pricing",
+        ),
+    ],
+    "deepseek": [
+        TokenPricing(
+            provider="deepseek",
+            model_match="deepseek-chat",
+            input_per_million_usd=0.28,
+            output_per_million_usd=0.42,
+            source_url="https://api-docs.deepseek.com/quick_start/pricing/",
+        ),
+        TokenPricing(
+            provider="deepseek",
+            model_match="deepseek-reasoner",
+            input_per_million_usd=0.55,
+            output_per_million_usd=2.19,
+            source_url="https://api-docs.deepseek.com/quick_start/pricing-details-usd",
+        ),
+    ],
+}
+
+
+def get_token_pricing(provider: str, model: str) -> TokenPricing | None:
+    provider_key = provider.strip().lower()
+    model_key = model.strip().lower()
+    candidates = _PRICING_RULES.get(provider_key, [])
+
+    for pricing in candidates:
+        if model_key == pricing.model_match.lower():
+            return pricing
+
+    for pricing in candidates:
+        if model_key.startswith(pricing.model_match.lower()):
+            return pricing
+
+    return None
+
+
+def estimate_token_cost(
+    provider: str,
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+) -> TokenCostEstimate:
+    return TokenCostEstimate(
+        provider=provider,
+        model=model,
+        pricing=get_token_pricing(provider=provider, model=model),
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+    )

--- a/Src/backtest/llm_signal_generator.py
+++ b/Src/backtest/llm_signal_generator.py
@@ -1,0 +1,307 @@
+"""
+backtest/llm_signal_generator.py
+สร้างสัญญาณ BUY/SELL/HOLD จาก LLM โดยใช้ข้อมูลย้อนหลังจริงทีละวัน
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass
+
+import pandas as pd
+
+from agent_core.llm.client import LLMCallResult, LLMClientFactory, PromptPackage
+from backtest.llm_pricing import estimate_token_cost, get_token_pricing
+from backtest.portfolio_engine import PortfolioSignal
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UsageSummary:
+    """สรุปการใช้ token ของการรัน backtest 1 รอบ"""
+
+    provider: str
+    model: str
+    total_calls: int = 0
+    successful_calls: int = 0
+    failed_calls: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    total_latency_ms: float = 0.0
+    last_error: str = ""
+
+    @property
+    def avg_latency_ms(self) -> float:
+        if self.successful_calls == 0:
+            return 0.0
+        return round(self.total_latency_ms / self.successful_calls, 2)
+
+    @property
+    def pricing(self):
+        return get_token_pricing(provider=self.provider, model=self.model)
+
+    @property
+    def input_cost_usd(self) -> float:
+        return estimate_token_cost(
+            provider=self.provider,
+            model=self.model,
+            prompt_tokens=self.prompt_tokens,
+            completion_tokens=self.completion_tokens,
+        ).input_cost_usd
+
+    @property
+    def output_cost_usd(self) -> float:
+        return estimate_token_cost(
+            provider=self.provider,
+            model=self.model,
+            prompt_tokens=self.prompt_tokens,
+            completion_tokens=self.completion_tokens,
+        ).output_cost_usd
+
+    @property
+    def total_cost_usd(self) -> float:
+        return estimate_token_cost(
+            provider=self.provider,
+            model=self.model,
+            prompt_tokens=self.prompt_tokens,
+            completion_tokens=self.completion_tokens,
+        ).total_cost_usd
+
+    @property
+    def pricing_source(self) -> str:
+        pricing = self.pricing
+        return pricing.source_url if pricing else ""
+
+    @property
+    def pricing_available(self) -> bool:
+        return self.pricing is not None
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["avg_latency_ms"] = self.avg_latency_ms
+        data["pricing_available"] = self.pricing_available
+        data["input_cost_usd"] = self.input_cost_usd
+        data["output_cost_usd"] = self.output_cost_usd
+        data["total_cost_usd"] = self.total_cost_usd
+        data["pricing_source"] = self.pricing_source
+        return data
+
+
+class LLMBacktestSignalGenerator:
+    """
+    สร้าง signal รายวันจาก LLM พร้อมสะสม usage metadata
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        model: str | None = None,
+        temperature: float = 0.2,
+        lookback_bars: int = 10,
+        use_mock: bool = False,
+    ):
+        kwargs: dict = {}
+        if model:
+            kwargs["model"] = model
+        if provider in {"openai", "groq", "deepseek"}:
+            kwargs["temperature"] = temperature
+        if provider == "gemini" and use_mock:
+            kwargs["use_mock"] = True
+
+        self.provider = provider
+        self.client = LLMClientFactory.create(provider, **kwargs)
+        self.model = getattr(self.client, "model", model or provider)
+        self.lookback_bars = max(3, lookback_bars)
+        self.usage_summary = UsageSummary(provider=provider, model=self.model)
+        self.call_records: list[LLMCallResult] = []
+
+    def generate_signals(
+        self,
+        train_data: pd.DataFrame,
+        test_data: pd.DataFrame,
+    ) -> tuple[list[PortfolioSignal], UsageSummary]:
+        """
+        สร้าง signal รายวัน โดยให้โมเดลเห็นข้อมูลถึงวันปัจจุบันเท่านั้น
+        """
+        all_data = (
+            pd.concat([train_data, test_data], ignore_index=True)
+            .sort_values("date")
+            .reset_index(drop=True)
+        )
+
+        signals: list[PortfolioSignal] = []
+        has_position = False
+
+        for _, row in test_data.iterrows():
+            as_of_date = pd.to_datetime(row["date"])
+            visible_data = all_data[all_data["date"] <= as_of_date].tail(self.lookback_bars)
+            prompt = self._build_prompt(visible_data, has_position)
+
+            self.usage_summary.total_calls += 1
+            try:
+                result = self.client.call_with_metadata(prompt)
+                self.call_records.append(result)
+                self._accumulate_usage(result)
+                parsed = self._extract_json(result.text)
+                signal_type, confidence, rationale = self._normalise_decision(
+                    parsed,
+                    has_position=has_position,
+                )
+                self.usage_summary.successful_calls += 1
+            except Exception as exc:
+                logger.warning(
+                    "[LLMBacktestSignalGenerator] %s failed on %s: %s",
+                    self.provider,
+                    as_of_date.date(),
+                    exc,
+                )
+                self.usage_summary.failed_calls += 1
+                signal_type = "HOLD"
+                confidence = 0.0
+                rationale = f"LLM fallback HOLD: {exc}"
+
+            signals.append(
+                PortfolioSignal(
+                    date=as_of_date.strftime("%Y-%m-%d"),
+                    signal=signal_type,
+                    confidence=confidence,
+                    model_name=self.provider,
+                    rationale=rationale,
+                )
+            )
+
+            if signal_type == "BUY":
+                has_position = True
+            elif signal_type == "SELL":
+                has_position = False
+
+        return signals, self.usage_summary
+
+    def _accumulate_usage(self, result: LLMCallResult) -> None:
+        self.usage_summary.prompt_tokens += result.prompt_tokens
+        self.usage_summary.completion_tokens += result.completion_tokens
+        self.usage_summary.total_tokens += result.total_tokens
+        self.usage_summary.total_latency_ms += result.latency_ms
+
+    def _build_prompt(self, visible_data: pd.DataFrame, has_position: bool) -> PromptPackage:
+        features = self._compute_features(visible_data)
+        recent_rows = []
+        for _, row in visible_data.tail(5).iterrows():
+            recent_rows.append(
+                {
+                    "date": pd.to_datetime(row["date"]).strftime("%Y-%m-%d"),
+                    "price_per_gram": round(float(row["price_per_gram"]), 2),
+                    "xau_close": round(float(row["xau_close"]), 2),
+                    "usdthb": round(float(row["usdthb"]), 4),
+                }
+            )
+
+        position_state = "LONG" if has_position else "FLAT"
+        allowed_signals = ["SELL", "HOLD"] if has_position else ["BUY", "HOLD"]
+
+        system = (
+            "You are a disciplined gold trading analyst running a backtest. "
+            "You can only use information provided in the prompt. "
+            "Return exactly one JSON object with keys: signal, confidence, rationale. "
+            "Signal must be one of BUY, SELL, HOLD."
+        )
+        user = (
+            f"As-of date: {features['as_of_date']}\n"
+            f"Portfolio state: {position_state}\n"
+            f"Allowed signals today: {', '.join(allowed_signals)}\n"
+            "Instrument: Gold priced in THB per gram.\n"
+            "Make one trading decision for today only.\n"
+            "Prefer HOLD when signals are mixed.\n\n"
+            "Latest computed features:\n"
+            f"{json.dumps(features, ensure_ascii=False, indent=2)}\n\n"
+            "Recent visible bars:\n"
+            f"{json.dumps(recent_rows, ensure_ascii=False, indent=2)}\n\n"
+            "Return JSON only. Example:\n"
+            '{"signal":"HOLD","confidence":0.55,"rationale":"short reason"}'
+        )
+        return PromptPackage(system=system, user=user, step_label="BACKTEST_SIGNAL")
+
+    def _compute_features(self, visible_data: pd.DataFrame) -> dict:
+        frame = visible_data.copy().reset_index(drop=True)
+        frame["return_pct"] = frame["price_per_gram"].pct_change() * 100
+        frame["sma_5"] = frame["price_per_gram"].rolling(5).mean()
+        frame["sma_10"] = frame["price_per_gram"].rolling(10).mean()
+
+        latest = frame.iloc[-1]
+        prev_price = float(frame["price_per_gram"].iloc[-2]) if len(frame) > 1 else float(latest["price_per_gram"])
+        momentum_base = float(frame["price_per_gram"].iloc[-6]) if len(frame) > 5 else prev_price
+        volatility_window = frame["return_pct"].tail(5).dropna()
+
+        return {
+            "as_of_date": pd.to_datetime(latest["date"]).strftime("%Y-%m-%d"),
+            "price_per_gram": round(float(latest["price_per_gram"]), 2),
+            "xau_close": round(float(latest["xau_close"]), 2),
+            "usdthb": round(float(latest["usdthb"]), 4),
+            "daily_return_pct": round(
+                ((float(latest["price_per_gram"]) / prev_price) - 1) * 100 if prev_price else 0.0,
+                3,
+            ),
+            "momentum_5d_pct": round(
+                ((float(latest["price_per_gram"]) / momentum_base) - 1) * 100 if momentum_base else 0.0,
+                3,
+            ),
+            "sma_5": round(float(latest["sma_5"]), 2) if pd.notna(latest["sma_5"]) else None,
+            "sma_10": round(float(latest["sma_10"]), 2) if pd.notna(latest["sma_10"]) else None,
+            "volatility_5d_pct": round(float(volatility_window.std()), 3)
+            if not volatility_window.empty
+            else 0.0,
+        }
+
+    @staticmethod
+    def _extract_json(raw_text: str) -> dict:
+        try:
+            return json.loads(raw_text.strip())
+        except json.JSONDecodeError:
+            pass
+
+        fenced = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", raw_text)
+        if fenced:
+            try:
+                return json.loads(fenced.group(1).strip())
+            except json.JSONDecodeError:
+                pass
+
+        brace = re.search(r"\{[\s\S]*\}", raw_text)
+        if brace:
+            try:
+                return json.loads(brace.group())
+            except json.JSONDecodeError:
+                pass
+
+        raise ValueError(f"Unable to parse JSON from LLM response: {raw_text[:200]}")
+
+    @staticmethod
+    def _normalise_decision(parsed: dict, has_position: bool) -> tuple[str, float, str]:
+        signal = str(parsed.get("signal", "HOLD")).upper().strip()
+        confidence = parsed.get("confidence", 0.0)
+        rationale = str(parsed.get("rationale", "")).strip()
+
+        try:
+            confidence = float(confidence)
+        except (TypeError, ValueError):
+            confidence = 0.0
+        confidence = max(0.0, min(1.0, confidence))
+
+        if signal not in {"BUY", "SELL", "HOLD"}:
+            signal = "HOLD"
+
+        if not has_position and signal == "SELL":
+            signal = "HOLD"
+            rationale = rationale or "SELL blocked because portfolio is flat"
+        elif has_position and signal == "BUY":
+            signal = "HOLD"
+            rationale = rationale or "BUY blocked because portfolio is already long"
+
+        if not rationale:
+            rationale = "No rationale provided"
+
+        return signal, confidence, rationale


### PR DESCRIPTION
ตอนนี้เพิ่มฝั่ง backtest ให้รองรับการใช้ LLM จริงแทน mock ได้แล้ว โดยเชื่อมเข้ากับระบบ LLMClient เดิม ทำให้สามารถทดสอบกับ provider อย่าง Gemini, Groq และตัวอื่นที่มีใน factory ได้โดยไม่ต้องเปลี่ยน flow ของ backtest หลัก

สิ่งที่เพิ่มเข้ามาคือระบบเก็บ metadata ของแต่ละ LLM call เช่น prompt tokens, output tokens, total tokens และ latency รวมถึง cost summary เป็น USD สำหรับใช้ประเมินว่าถ้ารัน backtest หลายรอบจะใช้ token และค่าใช้จ่ายประมาณเท่าไร ตอนนี้ฝั่งโค้ดพร้อมแล้ว เหลือแค่นำไปทดสอบบนเครื่องที่มี dependencies และ API keys ครบเพื่อยืนยันการรันจริง