### PR TITLE
Add USD/THB conversion and unit to ATR

### DIFF
--- a/Src/data_engine/indicators.py
+++ b/Src/data_engine/indicators.py
@@ -46,6 +46,7 @@ class ATRResult:
     value: float
     period: int = 14
     volatility_level: str = "normal"
+    unit: str = "USD_PER_OZ"
 
 
 @dataclass
@@ -79,7 +80,7 @@ class TechnicalIndicators:
     - Phase 2: ใช้ get_ml_dataframe() → ML-ready DataFrame
     """
 
-    def __init__(self, df: pd.DataFrame):
+    def __init__(self, df: pd.DataFrame, usd_thb: Optional[float] = None):
         if df.empty:
             raise ValueError("DataFrame is empty — cannot compute indicators")
         required = {"open", "high", "low", "close"}
@@ -90,6 +91,7 @@ class TechnicalIndicators:
         self.close = self.df["close"]
         self.high = self.df["high"]
         self.low = self.df["low"]
+        self.usd_thb = usd_thb  # Optional: ถ้าส่งมา atr() จะ convert เป็น THB ให้อัตโนมัติ
 
         # คำนวณ vectorized ล่วงหน้าทั้งหมด
         self._calculate_all_vectorized()
@@ -219,7 +221,16 @@ class TechnicalIndicators:
         else:
             vol_level = "normal"
 
-        return ATRResult(value=round(val, 2), period=14, volatility_level=vol_level)
+        # Convert USD/oz → THB ถ้ามี usd_thb ส่งเข้ามา
+        # สูตร: atr_thb = atr_usd_per_oz * usd_thb / 31.1035 * 15.244 * 0.965
+        # (แปลงเป็น THB ต่อ 1 บาททอง: หาร troy oz, คูณ gram/baht, คูณ purity)
+        if self.usd_thb is not None:
+            val = val * self.usd_thb / 31.1035 * 15.244 * 0.965
+            unit = "THB_PER_BAHT_GOLD"
+        else:
+            unit = "USD_PER_OZ"
+
+        return ATRResult(value=round(val, 2), period=14, volatility_level=vol_level, unit=unit)
 
     def trend(self) -> TrendResult:
         e20 = float(self.df["ema_20"].iloc[-1])


### PR DESCRIPTION
Expose optional usd_thb param and unit handling for ATR. Added a unit field to ATRResult, accepted an optional usd_thb argument in TechnicalIndicators.__init__ (stored as self.usd_thb), and updated atr() to convert the USD/oz ATR to THB per baht when usd_thb is provided using the provided conversion formula. The method now returns the appropriate unit (USD_PER_OZ or THB_PER_BAHT_GOLD) and still rounds the output; other validations and indicator calculations remain unchanged.