### PR TITLE
Start background gold price interceptor thread

### DIFF
--- a/Src/data_engine/orchestrator.py
+++ b/Src/data_engine/orchestrator.py
@@ -8,6 +8,8 @@ import json
 import os
 import argparse
 import logging
+import threading # <--- เพิ่มสำหรับจัดการ Background Thread
+import time      # <--- เพิ่มสำหรับการหน่วงเวลาใน Thread
 import pandas as pd
 from datetime import datetime
 from pathlib import Path
@@ -18,10 +20,40 @@ from data_engine.indicators import TechnicalIndicators
 from data_engine.newsfetcher import GoldNewsFetcher
 from data_engine.thailand_timestamp import get_thai_time, convert_index_to_thai_tz
 
+# ─── นำเข้าไฟล์ Interceptor ของเรา ───────────────────────────────────────────
+from data_engine.gold_interceptor_lite import start_interceptor
+
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+# ─── ส่วนจัดการ Background Thread (ป้องกันการรันซ้ำ) ───────────────────────
+_interceptor_thread_started = False
+_interceptor_lock = threading.Lock()
+
+def _run_interceptor_forever():
+    """ฟังก์ชันทำงานเบื้องหลัง: ดึงราคาทองค้างไว้ตลอดเวลา"""
+    logger.info("🚀 [Background Thread] เริ่มรันท่อ WebSocket (gold_interceptor_lite)...")
+    while True:
+        try:
+            start_interceptor()
+        except Exception as e:
+            logger.error(f"❌ [Background Thread] WebSocket หลุดหรือมีปัญหา: {e}")
+        
+        logger.info("🔄 [Background Thread] จะพยายามเชื่อมต่อใหม่ใน 5 วินาที...")
+        time.sleep(5)
+
+def _start_interceptor_background():
+    """ฟังก์ชันเช็คและเปิด Thread แค่ครั้งเดียวต่อการรัน 1 โปรเซส"""
+    global _interceptor_thread_started
+    with _interceptor_lock:
+        if not _interceptor_thread_started:
+            # daemon=True เพื่อให้ Thread นี้ปิดตัวเองอัตโนมัติถ้าโปรแกรมหลักทำงานเสร็จ/ถูกปิด
+            t = threading.Thread(target=_run_interceptor_forever, daemon=True)
+            t.start()
+            _interceptor_thread_started = True
+# ────────────────────────────────────────────────────────────────────────
 
 
 class GoldTradingOrchestrator:
@@ -34,6 +66,9 @@ class GoldTradingOrchestrator:
         max_news_per_cat: int = 5,
         output_dir: Optional[str] = None,
     ):
+        # 🟢 ทริกเกอร์ WebSocket ให้รันทันทีที่มีการเรียกใช้คลาสนี้ (และจะรันแค่ครั้งเดียว)
+        _start_interceptor_background()
+
         self.price_fetcher = GoldDataFetcher()
         self.news_fetcher = GoldNewsFetcher(max_per_category=max_news_per_cat)
         self.history_days = history_days
@@ -206,6 +241,15 @@ def main():
     payload = orchestrator.run(save_to_file=not args.no_save)
     # print(json.dumps(payload, indent=2, ensure_ascii=False, default=str)) # ปิด print ไว้จะได้ไม่รก Terminal
 
+    # --- ส่วนป้องกันการจบการทำงานของโปรแกรมหลัก (เฉพาะตอนเรียกแบบ CLI) ---
+    # เนื่องจาก Thread เป็นแบบ daemon ถ้า function main() จบ โปรแกรมจะปิดทันที
+    # เราจึงพักลูปไว้เพื่อให้ท่อ WebSocket ทำงานต่อไปได้
+    logger.info("🟢 [CLI Mode] รันคำสั่งเสร็จแล้ว กำลังเปิดท่อข้อมูลทิ้งไว้ กด Ctrl+C เพื่อออก...")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        logger.info("🔴 ปิดการทำงาน")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Run the gold_interceptor_lite WebSocket in a background daemon thread and ensure it is started only once per process. Adds threading and time imports, imports start_interceptor, and implements a supervisor loop that restarts the interceptor on error with a 5s backoff. Adds a lock and a boolean guard to prevent multiple thread starts, triggers the background thread from GoldTradingOrchestrator.__init__, and keeps the CLI process alive after main() so the daemon thread can continue running (Ctrl+C to exit). Includes additional informative logging.