### PR TITLE
Add ToolResultScorer and scoring pipeline

### DIFF
--- a/Src/data_engine/analysis_tools/technical_tools.py
+++ b/Src/data_engine/analysis_tools/technical_tools.py
@@ -40,16 +40,16 @@ def check_spot_thb_alignment(interval: str = "15m", lookback_candles: int = 4, d
  
         if spot_pct > 0 and thb_pct > 0:
             alignment = "Strong Bullish"
-            suggestion = "Spot UP & THB Weak (Bullish for Thai Gold)"
+
         elif spot_pct < 0 and thb_pct < 0:
             alignment = "Strong Bearish"
-            suggestion = "Spot DOWN & THB Strong (Bearish for Thai Gold)"
+          
         elif spot_pct > 0 and thb_pct < 0:
             alignment = "Neutral (Spot Leading)"
-            suggestion = "Spot UP & THB Strong (Slow rise or ranging)"
+
         else:
             alignment = "Neutral (THB Leading)"
-            suggestion = "Spot DOWN & THB Weak (Slow drop or ranging)"
+            
  
         return {
             "status": "success",
@@ -59,7 +59,7 @@ def check_spot_thb_alignment(interval: str = "15m", lookback_candles: int = 4, d
                 "spot_pct_change": round(spot_pct, 4),
                 "thb_pct_change": round(thb_pct, 4)
             },
-            "suggestion": suggestion
+
         }
     except Exception as e:
         return {"status": "error", "message": str(e)}
@@ -87,7 +87,6 @@ def detect_breakout_confirmation(zone_top: float, zone_bottom: float, interval: 
             return {
                 "status": "success",
                 "is_confirmed_breakout": False,
-                "suggestion": "Price ranging inside zone, no breakout"
             }
 
         body_size = abs(close_p - open_p)
@@ -97,7 +96,6 @@ def detect_breakout_confirmation(zone_top: float, zone_bottom: float, interval: 
             return {
                 "status": "success",
                 "is_confirmed_breakout": False,
-                "suggestion": "Doji candle detected, cannot confirm breakout"
             }
 
         body_pct = (body_size / total_size) * 100
@@ -123,7 +121,7 @@ def detect_breakout_confirmation(zone_top: float, zone_bottom: float, interval: 
                 "body_strength_pct": round(float(body_pct), 2),
                 "closed_price": round(float(close_p), 2)
             },
-            "suggestion": "Confirmed breakout, safe to follow trend" if confirmed else "Weak signal, potential fakeout"
+            
         }
     except Exception as e:
         return {"status": "error", "message": str(e)}
@@ -248,7 +246,7 @@ def detect_swing_low(interval: str = "15m", history_days: int = 3, lookback_cand
                 "swing_low_price": round(float(swing_low_val), 2) if swing_low_val else None,
                 "confirmation_close": round(float(confirmation_close), 2) if confirmation_close else None
             },
-            "suggestion": "Potential Bullish Reversal" if setup_found else "No clear swing low detected"
+            
         }
     except Exception as e:
         return {"status": "error", "message": str(e)}
@@ -381,7 +379,7 @@ def calculate_ema_distance(interval: str = "15m", history_days: int = 5, ohlcv_d
                 "ema_20": round(ema_20, 2),
                 "atr": round(atr, 2)
             },
-            "suggestion": "Highly overextended, mean reversion likely" if is_overextended else "Normal distance, trend continuation possible" 
+            
         }
     except Exception as e:
         return {"status": "error", "message": str(e)}
@@ -446,7 +444,7 @@ def get_htf_trend(timeframe: str = "1h", history_days: int = 15, ohlcv_df: pd.Da
             "current_price": round(float(current_price), 2),
             "ema_200": round(float(ema_200), 2),
             "distance_from_ema_pct": round(float(distance_pct), 2),
-            "suggestion": f"Main trend is {trend}, look for {'Buy' if trend == 'Bullish' else 'Sell'} setups"
+
         }
 
         # 6. บันทึกผลลัพธ์ลง Cache ก่อนส่งกลับไปให้ AI

--- a/Src/data_engine/ohlcv_fetcher.py
+++ b/Src/data_engine/ohlcv_fetcher.py
@@ -87,8 +87,19 @@ def _calculate_fetch_days(
     if len(cached_df) < min_candles:
         return requested_days
 
-    last_time = cached_df.index[-1]
     now = pd.Timestamp.now('UTC')
+
+    # เช็คว่า cache ครอบคลุม requested_days ครบไหม
+    # ถ้า oldest candle ใน cache ใหม่กว่า cutoff ที่ต้องการ → fetch เต็ม
+    required_cutoff = now - pd.Timedelta(days=requested_days)
+    oldest_cached   = cached_df.index[0]
+
+    if oldest_cached > required_cutoff:
+        print(f"[CACHE] Cache starts at {oldest_cached.date()} but need data from {required_cutoff.date()} → full fetch")
+        return requested_days
+
+    # cache ครอบคลุมแล้ว → fetch แค่ส่วนที่หายไป (incremental)
+    last_time  = cached_df.index[-1]
     delta_days = (now - last_time) / pd.Timedelta(days=1)
 
     if delta_days < requested_days:

--- a/Src/data_engine/tools/fetch_price.py
+++ b/Src/data_engine/tools/fetch_price.py
@@ -76,7 +76,6 @@ def fetch_price(
     return {
         "spot_price_usd":      spot_data,
         "thai_gold_thb":       thai_gold,
-        "forex":               raw.get("forex", {}),
         "recent_price_action": recent_price_action,
         "ohlcv_df":            ohlcv_df,
         "data_sources": {

--- a/Src/data_engine/tools/tool_registry.py
+++ b/Src/data_engine/tools/tool_registry.py
@@ -1,15 +1,28 @@
 """
 tools/tool_registry.py — Registry สำหรับ LLM Agent
-รวม tools ไว้ที่เดียว แยกส่วน Internal (Orchestrator) และ Public (LLM) 
+รวม tools ไว้ที่เดียว แยกส่วน Internal (Orchestrator) และ Public (LLM)
 
 Usage:
     from data_engine.tools.tool_registry import call_tool, list_tools, AVAILABLE_TOOLS_INFO
 
-    # Orchestrator เรียกได้ (Internal)
+    # Orchestrator เรียกได้ (Internal) — ไม่ผ่าน scorer
     result = call_tool("fetch_price", interval="5m", history_days=30)
-    
-    # LLM เรียกได้ (Public)
+
+    # LLM เรียกได้ (Public) — ไม่ผ่าน scorer (single call เดิม)
     result = call_tool("detect_swing_low", interval="15m", history_days=3)
+
+    # ─── NEW: เรียก tools พร้อม scoring ในครั้งเดียว ───────────────
+    from data_engine.tools.tool_registry import execute_with_scoring
+
+    report = execute_with_scoring([
+        ("check_upcoming_economic_calendar", {"hours_ahead": 24}),
+        ("detect_breakout_confirmation",     {"zone_top": 3250, "zone_bottom": 3200, "interval": "15m"}),
+    ])
+
+    if report.should_proceed:
+        llm_context = [ts.tool_name for ts in report.tool_scores]  # ส่งต่อ LLM ได้เลย
+    else:
+        print(report.recommendations)   # ดูว่าต้อง call tool เพิ่มอะไร
 """
 
 import logging
@@ -20,11 +33,17 @@ from tools.fetch_indicators import fetch_indicators
 from tools.fetch_news       import fetch_news
 from tools.schema_validator import validate_market_state
 
-# 1. Import จากโฟลเดอร์ analysis_tools 
+# 1. Import จากโฟลเดอร์ analysis_tools
 from data_engine.analysis_tools import TOOL_REGISTRY as ANALYSIS_TOOL_REGISTRY
 from data_engine.analysis_tools import AVAILABLE_TOOLS_INFO as ANALYSIS_TOOLS_INFO
 
+# ─── NEW: Import ToolResultScorer ──────────────────────────────────────────────
+from tools.tool_result_scorer import ToolResult, ToolResultScorer, ScoreReport
+
 logger = logging.getLogger(__name__)
+
+# ─── Scorer singleton (สร้างครั้งเดียว ใช้ร่วมกันทั้งไฟล์) ──────────────────────
+_scorer = ToolResultScorer()
 
 # 2. Internal Tools (ใช้โดย Orchestrator เพื่อสร้าง market_state ห้ามให้ LLM เห็น)
 INTERNAL_TOOLS: dict[str, Any] = {
@@ -43,18 +62,23 @@ TOOL_REGISTRY = {**INTERNAL_TOOLS, **LLM_TOOLS}
 AVAILABLE_TOOLS_INFO = ANALYSIS_TOOLS_INFO
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# ฟังก์ชันเดิม — ไม่เปลี่ยนแปลง (Backward Compatible)
+# ─────────────────────────────────────────────────────────────────────────────
+
 def call_tool(tool_name: str, **kwargs: Any) -> dict:
     """
     เรียก tool จาก TOOL_REGISTRY (Orchestrator และ LLM เรียกผ่านที่นี่)
+    คืน dict ตรงๆ ไม่ผ่าน scorer — เหมือนเดิมทุกอย่าง
     """
     if tool_name not in TOOL_REGISTRY:
         available = list(TOOL_REGISTRY.keys())
         raise KeyError(f"Tool '{tool_name}' not found. Available: {available}")
 
     logger.info(f"[ToolRegistry] Calling '{tool_name}' with params={list(kwargs.keys())}")
-    
+
     tool_target = TOOL_REGISTRY[tool_name]
-    
+
     # Smart Check: รองรับทั้ง Dictionary ที่มี "fn" และ Function ตรงๆ
     if isinstance(tool_target, dict) and "fn" in tool_target:
         return tool_target["fn"](**kwargs)
@@ -71,15 +95,167 @@ def list_tools() -> list[dict]:
     for name, meta in LLM_TOOLS.items():
         if isinstance(meta, dict) and "description" in meta:
             tools_list.append({
-                "name": name, 
-                "description": meta["description"], 
-                "parameters": meta.get("parameters", {})
+                "name": name,
+                "description": meta["description"],
+                "parameters": meta.get("parameters", {}),
             })
         else:
             # Fallback ป้องกัน list_tools() พัง
             tools_list.append({
-                "name": name, 
-                "description": f"Advanced Analysis Tool: {name}", 
-                "parameters": {}
+                "name": name,
+                "description": f"Advanced Analysis Tool: {name}",
+                "parameters": {},
             })
     return tools_list
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# NEW — ฟังก์ชันเสริม สำหรับ Scoring Pipeline
+# ─────────────────────────────────────────────────────────────────────────────
+
+def call_tool_as_result(
+    tool_name: str,
+    weight: float = 1.0,
+    **kwargs: Any,
+) -> ToolResult:
+    """
+    เรียก tool เดียว แล้วห่อผลลัพธ์เป็น ToolResult ทันที
+
+    ใช้เมื่อต้องการ call tool ทีละตัวแต่ยังอยากรวม score ทีหลัง
+    Internal Tools (fetch_price ฯลฯ) ก็เรียกได้ แต่ scorer จะ skip ถ้าชื่อไม่รู้จัก
+
+    Args:
+        tool_name: ชื่อ tool ใน TOOL_REGISTRY
+        weight:    ความสำคัญของ tool นี้ใน context ปัจจุบัน (default 1.0)
+        **kwargs:  params ส่งต่อให้ tool ตรงๆ
+
+    Returns:
+        ToolResult พร้อม output และ params ที่ใช้ call
+    """
+    output = call_tool(tool_name, **kwargs)
+    return ToolResult(
+        tool_name=tool_name,
+        output=output,
+        params=dict(kwargs),
+        weight=weight,
+    )
+
+
+def execute_with_scoring(
+    tool_calls: list[tuple[str, dict]],
+    weights: dict[str, float] | None = None,
+    max_rounds: int = 3,
+) -> ScoreReport:
+    """
+    เรียก tools หลายตัวพร้อมกัน → score → loop ถ้าคะแนนไม่ถึง 0.6
+
+    Pipeline:
+        1. Call tools ทุกตัวใน tool_calls
+        2. ส่งผลทั้งหมดเข้า ToolResultScorer
+        3. ถ้า avg score < 0.6 → call tools ที่ scorer แนะนำเพิ่ม
+        4. วน loop ซ้ำจนกว่าจะผ่าน หรือครบ max_rounds
+        5. คืน ScoreReport สุดท้าย (should_proceed + tool_scores + recommendations)
+
+    Args:
+        tool_calls:  list ของ (tool_name, params_dict) ที่จะ call รอบแรก
+                     ตย. [("detect_breakout_confirmation", {"interval": "15m"})]
+        weights:     dict ของ {tool_name: weight} สำหรับ tool ที่ต้องการให้น้ำหนักพิเศษ
+                     ตย. {"check_upcoming_economic_calendar": 1.5}
+                     tool ที่ไม่ระบุ weight จะได้ 1.0
+        max_rounds:  จำนวนรอบ retry สูงสุด (default 3) ป้องกัน infinite loop
+
+    Returns:
+        ScoreReport ที่มี:
+            - tool_scores:       คะแนนและเหตุผลของแต่ละ tool
+            - avg_score:         weighted average ของทุก tool
+            - should_proceed:    True ถ้าพร้อมส่งเข้า LLM
+            - recommendations:   tool ที่ควร call เพิ่ม (ว่างถ้า should_proceed=True)
+            - summary:           สรุปสั้นๆ สำหรับ log
+
+    Example:
+        report = execute_with_scoring(
+            tool_calls=[
+                ("check_upcoming_economic_calendar", {"hours_ahead": 24}),
+                ("detect_breakout_confirmation",     {"zone_top": 3250, "zone_bottom": 3200, "interval": "15m"}),
+                ("get_htf_trend",                   {"timeframe": "1h"}),
+            ],
+            weights={"check_upcoming_economic_calendar": 1.5},
+            max_rounds=3,
+        )
+
+        if report.should_proceed:
+            # รวม outputs ทั้งหมดเพื่อส่งเข้า LLM
+            llm_context = {ts.tool_name: ... for ts in report.tool_scores}
+        else:
+            # ดู recommendations เพื่อตัดสินใจว่าจะ retry หรือ proceed ด้วย context ที่มี
+            for rec in report.recommendations:
+                print(f"แนะนำ call: {rec.recommended_tool} params={rec.suggested_params}")
+    """
+    weights = weights or {}
+
+    # ── Round 1: Call tools ชุดแรก ─────────────────────────────────────────
+    results: list[ToolResult] = []
+    for tool_name, params in tool_calls:
+        try:
+            w = weights.get(tool_name, 1.0)
+            result = call_tool_as_result(tool_name, weight=w, **params)
+            results.append(result)
+        except KeyError as e:
+            logger.warning(f"[execute_with_scoring] Tool ไม่พบ: {e} — ข้ามไป")
+        except Exception as e:
+            # ถ้า tool crash → สร้าง ToolResult ที่ status=error เพื่อให้ scorer ให้ 0.0
+            logger.error(f"[execute_with_scoring] '{tool_name}' error: {e}")
+            results.append(ToolResult(
+                tool_name=tool_name,
+                output={"status": "error", "message": str(e)},
+                params=params,
+                weight=weights.get(tool_name, 1.0),
+            ))
+
+    report = _scorer.score(results)
+    logger.info(f"[execute_with_scoring] Round 1 — {report.summary}")
+
+    # ── Retry Loop: ตาม recommendations จนกว่าผ่านหรือหมด rounds ──────────
+    for round_num in range(2, max_rounds + 1):
+        if report.should_proceed:
+            break
+
+        if not report.recommendations:
+            logger.info(f"[execute_with_scoring] ไม่มี recommendations เหลือ — หยุดที่ round {round_num - 1}")
+            break
+
+        logger.info(f"[execute_with_scoring] Round {round_num} — call {len(report.recommendations)} tools เพิ่ม")
+
+        for rec in report.recommendations:
+            try:
+                w = weights.get(rec.recommended_tool, 1.0)
+                new_result = call_tool_as_result(rec.recommended_tool, weight=w, **rec.suggested_params)
+                results.append(new_result)
+                logger.info(f"[execute_with_scoring] ✅ '{rec.recommended_tool}' called — reason: {rec.reason}")
+            except KeyError as e:
+                logger.warning(f"[execute_with_scoring] Recommended tool ไม่พบ: {e} — ข้ามไป")
+            except Exception as e:
+                logger.error(f"[execute_with_scoring] '{rec.recommended_tool}' error: {e}")
+                results.append(ToolResult(
+                    tool_name=rec.recommended_tool,
+                    output={"status": "error", "message": str(e)},
+                    params=rec.suggested_params,
+                    weight=w,
+                ))
+
+        report = _scorer.score(results)
+        logger.info(f"[execute_with_scoring] Round {round_num} — {report.summary}")
+
+    # ── Log สรุปผลสุดท้าย ──────────────────────────────────────────────────
+    if report.should_proceed:
+        logger.info(
+            f"[execute_with_scoring] ✅ PROCEED — avg={report.avg_score:.3f} "
+            f"| {len(results)} tools called"
+        )
+    else:
+        logger.warning(
+            f"[execute_with_scoring] ⚠️ LOW SCORE หลัง {max_rounds} rounds — "
+            f"avg={report.avg_score:.3f} | proceed ต่อด้วย context ที่มีอยู่"
+        )
+
+    return report

--- a/Src/data_engine/tools/tool_result_scorer.py
+++ b/Src/data_engine/tools/tool_result_scorer.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data Structures
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class ToolResult:
+    """Wrapper สำหรับผลลัพธ์จาก tool call หนึ่งครั้ง"""
+    tool_name: str                                          # ชื่อ function เป๊ะๆ
+    output: dict                                            # dict ที่ tool return มาตรงๆ
+    params: dict                                            # params ที่ใช้ call (สำหรับ recommendation)
+    called_at: datetime = field(default_factory=datetime.utcnow)
+    weight: float = 1.0                                     # ความสำคัญของ tool นี้ใน context ปัจจุบัน
+
+
+@dataclass
+class ToolScore:
+    """คะแนนและเหตุผลของ tool หนึ่งตัว"""
+    tool_name: str
+    score: float                                            # 0.0 – 1.0
+    reason: str                                             # อธิบายว่าทำไมได้คะแนนนี้
+    weight: float
+    weighted_score: float                                   # score * weight (คำนวณให้แล้ว)
+
+
+@dataclass
+class Recommendation:
+    """คำแนะนำให้ call tool เพิ่ม"""
+    source_tool: str                                        # tool ที่ score ต่ำ (เหตุผลที่แนะนำ)
+    recommended_tool: str                                   # tool ที่ควร call เพิ่ม
+    suggested_params: dict                                  # params ที่แนะนำ (อ้างอิงจาก source params)
+    reason: str
+
+
+@dataclass
+class ScoreReport:
+    """ผลลัพธ์รวมของ ToolResultScorer"""
+    tool_scores: list[ToolScore]
+    avg_score: float
+    should_proceed: bool                                    # True ถ้า avg >= 0.6
+    recommendations: list[Recommendation]                  # ว่างถ้า should_proceed = True
+    summary: str                                            # สรุปสั้นๆ สำหรับ log
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scorer
+# ─────────────────────────────────────────────────────────────────────────────
+
+PROCEED_THRESHOLD = 0.6
+FLOOR_SCORE = 0.2       # score ขั้นต่ำสำหรับ result ที่ไม่มี signal (ไม่ใช่ error)
+
+
+class ToolResultScorer:
+    """
+    ประเมินคุณภาพของ ToolResult แต่ละตัวก่อนส่งเข้า LLM context
+
+    Usage:
+        results = [
+            ToolResult("detect_breakout_confirmation", output={...}, params={...}),
+            ToolResult("check_upcoming_economic_calendar", output={...}, params={...}, weight=1.5),
+        ]
+        report = ToolResultScorer().score(results)
+        if report.should_proceed:
+            # ส่ง results เข้า LLM ได้เลย
+        else:
+            # ดู report.recommendations แล้ว call tool เพิ่ม
+    """
+
+    # ─── Recommendation Map ───────────────────────────────────────────────────
+
+    _RECOMMENDATION_MAP: dict[str, list[str]] = {
+        "detect_breakout_confirmation":   ["get_support_resistance_zones", "check_bb_rsi_combo"],
+        "check_bb_rsi_combo":             ["detect_rsi_divergence", "calculate_ema_distance"],
+        "detect_rsi_divergence":          ["check_bb_rsi_combo", "detect_breakout_confirmation"],
+        "calculate_ema_distance":         ["get_htf_trend", "check_spot_thb_alignment"],
+        "get_support_resistance_zones":   ["detect_breakout_confirmation"],
+        "get_htf_trend":                  ["check_spot_thb_alignment"],
+        "check_spot_thb_alignment":       ["get_htf_trend"],
+        "check_upcoming_economic_calendar": ["get_intermarket_correlation"],
+        "get_deep_news_by_category":      [],               # handled specially (retry + new category)
+        "get_intermarket_correlation":    ["check_upcoming_economic_calendar", "get_deep_news_by_category"],
+    }
+
+    # ─── Public API ───────────────────────────────────────────────────────────
+
+    def score(self, results: list[ToolResult]) -> ScoreReport:
+        """
+        รับ list ของ ToolResult แล้วคืน ScoreReport พร้อม recommendations
+        """
+        if not results:
+            return ScoreReport(
+                tool_scores=[],
+                avg_score=0.0,
+                should_proceed=False,
+                recommendations=[],
+                summary="ไม่มี tool results ส่งมา",
+            )
+
+        tool_scores: list[ToolScore] = []
+        for tr in results:
+            score, reason = self._dispatch(tr)
+            weighted = round(score * tr.weight, 4)
+            tool_scores.append(ToolScore(
+                tool_name=tr.tool_name,
+                score=score,
+                reason=reason,
+                weight=tr.weight,
+                weighted_score=weighted,
+            ))
+
+        # weighted average
+        total_weight = sum(ts.weight for ts in tool_scores)
+        avg_score = round(
+            sum(ts.weighted_score for ts in tool_scores) / total_weight, 4
+        ) if total_weight > 0 else 0.0
+
+        should_proceed = avg_score >= PROCEED_THRESHOLD
+
+        recommendations: list[Recommendation] = []
+        if not should_proceed:
+            already_called = {tr.tool_name for tr in results}
+            for tr, ts in zip(results, tool_scores):
+                if ts.score < PROCEED_THRESHOLD:
+                    recs = self._build_recommendations(tr, already_called)
+                    recommendations.extend(recs)
+                    # เพิ่ม recommended tools เข้า already_called เพื่อกัน duplicate
+                    for r in recs:
+                        already_called.add(r.recommended_tool)
+
+        summary = self._build_summary(tool_scores, avg_score, should_proceed)
+        logger.info(f"[ToolResultScorer] {summary}")
+
+        return ScoreReport(
+            tool_scores=tool_scores,
+            avg_score=avg_score,
+            should_proceed=should_proceed,
+            recommendations=recommendations,
+            summary=summary,
+        )
+
+    # ─── Dispatch ─────────────────────────────────────────────────────────────
+
+    def _dispatch(self, tr: ToolResult) -> tuple[float, str]:
+        """เลือก scorer ที่ถูกต้องตาม tool_name"""
+        scorer_map = {
+            "detect_breakout_confirmation":     self._score_breakout_confirmation,
+            "check_bb_rsi_combo":               self._score_bb_rsi_combo,
+            "detect_rsi_divergence":            self._score_rsi_divergence,
+            "calculate_ema_distance":           self._score_ema_distance,
+            "get_support_resistance_zones":     self._score_support_resistance,
+            "get_htf_trend":                    self._score_htf_trend,
+            "check_spot_thb_alignment":         self._score_spot_thb_alignment,
+            "check_upcoming_economic_calendar": self._score_economic_calendar,
+            "get_deep_news_by_category":        self._score_deep_news,
+            "get_intermarket_correlation":      self._score_intermarket_correlation,
+        }
+        fn = scorer_map.get(tr.tool_name)
+        if fn is None:
+            logger.warning(f"[ToolResultScorer] ไม่รู้จัก tool '{tr.tool_name}' ใช้ generic scorer")
+            return self._score_generic(tr.output)
+        return fn(tr.output)
+
+    # ─── Generic (fallback) ───────────────────────────────────────────────────
+
+    def _score_generic(self, output: dict) -> tuple[float, str]:
+        if output.get("status") == "error":
+            return 0.0, f"Tool error: {output.get('message', 'unknown')}"
+        return FLOOR_SCORE, "Tool ไม่รู้จัก — ให้ floor score"
+
+    # ─── Technical Tools ──────────────────────────────────────────────────────
+
+    def _score_breakout_confirmation(self, output: dict) -> tuple[float, str]:
+        if output.get("status") == "error":
+            return 0.0, f"Error: {output.get('message')}"
+
+        confirmed = output.get("is_confirmed_breakout", False)
+        if not confirmed:
+            return FLOOR_SCORE, "ไม่มี breakout confirmation"
+
+        body_strength = output.get("details", {}).get("body_strength_pct", 0.0)
+        score = 0.85
+        reason = f"Breakout confirmed | body_strength={body_strength:.1f}%"
+
+        if body_strength >= 70.0:
+            score += 0.10
+            reason += " → body แข็งแกร่งมาก (+0.10)"
+
+        return min(score, 1.0), reason
+
+    def _score_bb_rsi_combo(self, output: dict) -> tuple[float, str]:
+        if output.get("status") == "error":
+            return 0.0, f"Error: {output.get('message')}"
+
+        if output.get("combo_detected", False):
+            return 0.85, "BB+RSI+MACD combo detected — oversold signal ชัดเจน"
+        return FLOOR_SCORE, "ไม่ครบ combo conditions"
+
+    def _score_rsi_divergence(self, output: dict) -> tuple[float, str]:
+        if output.get("status") == "error":
+            return 0.0, f"Error: {output.get('message')}"
+
+        if output.get("divergence_detected", False):
+            data = output.get("data", {})
+            return 0.85, (
+                f"Bullish RSI divergence detected | "
+                f"Low1={data.get('Low1')} RSI1={data.get('RSI1')} → "
+                f"Low2={data.get('Low2')} RSI2={data.get('RSI2')}"
+            )
+        return FLOOR_SCORE, f"ไม่พบ divergence: {output.get('logic', '')}"
+
+    def _score_ema_distance(self, output: dict) -> tuple[float, str]:
+        if output.get("status") == "error":
+            return 0.0, f"Error: {output.get('message')}"
+
+        overextended = output.get("is_overextended", False)
+        distance = abs(output.get("distance_atr_ratio", 0.0))
+
+        if not overextended:
+            return FLOOR_SCORE, f"ราคาใกล้ EMA20 — distance={distance:.2f} ATR"
+
+        score = 0.75
+        reason = f"Price overextended จาก EMA20 | distance={distance:.2f} ATR"
+        if distance >= 7.0:
+            score += 0.15
+            reason += " → ไกลมาก (+0.15)"
+
+        return min(score, 1.0), reason
+
+    def _score_support_resistance(self, output: dict) -> tuple[float, str]:
+        if output.get("status") == "error":
+            return 0.0, f"Error: {output.get('message')}"
+
+        zones: list[dict] = output.get("zones", [])
+        current_price: float = output.get("current_price", 0.0)
+        atr: float = output.get("adaptive_metrics", {}).get("atr_used", 0.0)
+
+        if not zones:
+            return FLOOR_SCORE, "ไม่พบ S/R zone เลย"
+
+        # หา zone ที่ราคาอยู่ภายใน 1 ATR
+        nearby_zones = []
+        for z in zones:
+            top = z.get("top", 0.0)
+            bottom = z.get("bottom", 0.0)
+            if atr > 0:
+                if (bottom - atr) <= current_price <= (top + atr):
+                    nearby_zones.append(z)
+            else:
+                # fallback ถ้าไม่มี ATR: ใช้ 0.5% ของราคา
+                tolerance = current_price * 0.005
+                if (bottom - tolerance) <= current_price <= (top + tolerance):
+                    nearby_zones.append(z)
+
+        if not nearby_zones:
+            return 0.4, f"มี {len(zones)} zones แต่ราคาไม่ใกล้ zone ใดเลย"
+
+        best = max(nearby_zones, key=lambda z: {"High": 3, "Medium": 2, "Low": 1}.get(z.get("strength", "Low"), 1))
+        strength = best.get("strength", "Low")
+
+        score_map = {"Low": 0.6, "Medium": 0.75, "High": 0.9}
+        score = score_map.get(strength, 0.6)
+        reason = (
+            f"ราคาใกล้ {len(nearby_zones)} zone | "
+            f"strongest={strength} ({best.get('bottom')}–{best.get('top')})"
+        )
+        return score, reason
+
+    def _score_htf_trend(self, output: dict) -> tuple[float, str]:
+        if output.get("status") == "error":
+            return 0.0, f"Error: {output.get('message')}"
+
+        trend = output.get("trend", "")
+        distance_pct = abs(output.get("distance_from_ema_pct", 0.0))
+
+        if trend not in ("Bullish", "Bearish"):
+            return FLOOR_SCORE, f"Trend ไม่ชัดเจน: {trend}"
+
+        if distance_pct >= 1.5:
+            return 0.75, f"HTF trend {trend} | ห่าง EMA200 {distance_pct:.2f}% — ชัดเจน"
+        return 0.5, f"HTF trend {trend} แต่ใกล้ EMA200 ({distance_pct:.2f}%) — อาจ consolidate"
+
+    def _score_spot_thb_alignment(self, output: dict) -> tuple[float, str]:
+        if output.get("status") == "error":
+            return 0.0, f"Error: {output.get('message')}"
+
+        alignment = output.get("alignment", "")
+        if alignment in ("Strong Bullish", "Strong Bearish"):
+            details = output.get("details", {})
+            return 0.85, (
+                f"Alignment ชัดเจน: {alignment} | "
+                f"spot={details.get('spot_pct_change')}% "
+                f"thb={details.get('thb_pct_change')}%"
+            )
+        return 0.3, f"Alignment: {alignment} — ทิศทางสวนกัน ไม่มี strong signal"
+
+    # ─── Fundamental Tools ────────────────────────────────────────────────────
+
+    def _score_economic_calendar(self, output: dict) -> tuple[float, str]:
+        if output.get("status") == "error":
+            return 0.0, f"Error: {output.get('message')}"
+
+        risk_map = {
+            "critical": (1.0, "🔴 CRITICAL risk — มีข่าวใหญ่ใกล้ออก"),
+            "high":     (0.8, "🟠 HIGH risk — ควรระวัง"),
+            "medium":   (0.5, "🟡 MEDIUM risk — มีข่าว medium impact"),
+            "low":      (FLOOR_SCORE, "🟢 LOW risk — ไม่มีข่าวสำคัญ"),
+        }
+        risk_level = output.get("risk_level", "low")
+        score, reason = risk_map.get(risk_level, (FLOOR_SCORE, f"Unknown risk level: {risk_level}"))
+        return score, reason
+
+    def _score_deep_news(self, output: dict) -> tuple[float, str]:
+        if output.get("status") == "error":
+            return 0.0, f"Error: {output.get('message')}"
+
+        count = output.get("count", 0)
+        if count == 0:
+            return FLOOR_SCORE, "ไม่พบบทความเลย"
+        if count <= 2:
+            return 0.5, f"พบ {count} บทความ — น้อย"
+        if count <= 4:
+            return 0.7, f"พบ {count} บทความ — พอใช้"
+        return 0.85, f"พบ {count} บทความ — ครบถ้วน"
+
+    def _score_intermarket_correlation(self, output: dict) -> tuple[float, str]:
+        if output.get("status") == "error":
+            return 0.0, f"Error: {output.get('message')}"
+
+        divergences: list[dict] = output.get("divergences", [])
+        warnings = [d for d in divergences if d.get("status") in ("bearish_warning", "bullish_warning")]
+        flat_or_normal = all(d.get("status") in ("normal", "flat") for d in divergences)
+
+        if len(warnings) >= 2:
+            return 1.0, f"มี divergence warning ทั้ง {len(warnings)} pairs — signal แข็งมาก"
+        if len(warnings) == 1:
+            w = warnings[0]
+            return 0.75, f"มี divergence warning: {w.get('pair')} ({w.get('status')}) — {w.get('note', '')}"
+        if flat_or_normal and divergences:
+            statuses = [d.get("status") for d in divergences]
+            if all(s == "flat" for s in statuses):
+                return FLOOR_SCORE, "ทุก pair flat — ตลาดนิ่งมาก"
+            return 0.3, "ทุก pair normal inverse — ไม่มีความผิดปกติ"
+        return FLOOR_SCORE, "ไม่มีข้อมูล divergence"
+
+    # ─── Recommendation Builder ───────────────────────────────────────────────
+
+    def _build_recommendations(
+        self,
+        tr: ToolResult,
+        already_called: set[str],
+    ) -> list[Recommendation]:
+        recs: list[Recommendation] = []
+
+        # กรณีพิเศษ: get_deep_news_by_category → แนะนำ retry ด้วย category อื่น
+        if tr.tool_name == "get_deep_news_by_category":
+            current_category = tr.params.get("category", "")
+            all_categories = [
+                "gold_price", "usd_thb", "fed_policy", "inflation",
+                "geopolitics", "dollar_index", "thai_economy", "thai_gold_market",
+            ]
+            for cat in all_categories:
+                if cat != current_category:
+                    recs.append(Recommendation(
+                        source_tool=tr.tool_name,
+                        recommended_tool="get_deep_news_by_category",
+                        suggested_params={"category": cat},
+                        reason=f"ข่าว category '{current_category}' ไม่เพียงพอ → ลอง '{cat}'",
+                    ))
+                    break   # แนะนำแค่ category ถัดไป 1 อัน ไม่ flood
+            return recs
+
+        # กรณีทั่วไป
+        suggested_tools = self._RECOMMENDATION_MAP.get(tr.tool_name, [])
+        for suggested in suggested_tools:
+            if suggested in already_called:
+                continue
+
+            # สืบทอด params ที่ compatible (interval, history_days)
+            inherited_params: dict[str, Any] = {}
+            for key in ("interval", "history_days", "timeframe"):
+                if key in tr.params:
+                    inherited_params[key] = tr.params[key]
+
+            recs.append(Recommendation(
+                source_tool=tr.tool_name,
+                recommended_tool=suggested,
+                suggested_params=inherited_params,
+                reason=f"'{tr.tool_name}' score ต่ำ → เพิ่มข้อมูลด้วย '{suggested}'",
+            ))
+
+        return recs
+
+    # ─── Summary Builder ──────────────────────────────────────────────────────
+
+    def _build_summary(
+        self,
+        tool_scores: list[ToolScore],
+        avg_score: float,
+        should_proceed: bool,
+    ) -> str:
+        status = "✅ PROCEED" if should_proceed else "🔄 NEED MORE TOOLS"
+        scores_str = " | ".join(
+            f"{ts.tool_name}={ts.score:.2f}(x{ts.weight})" for ts in tool_scores
+        )
+        return f"{status} | avg={avg_score:.3f} | {scores_str}"


### PR DESCRIPTION
Introduce a ToolResultScorer (new tools/tool_result_scorer.py) to evaluate and recommend additional tool calls before sending context to the LLM. Integrate the scorer into tool registry: add a singleton scorer, call_tool_as_result helper, and execute_with_scoring which calls multiple tools, scores outputs, and retries recommended tools until a threshold or max rounds. Adjustments: improved incremental fetch logic in ohlcv_fetcher (check oldest cached candle to decide full vs incremental fetch), removed 'forex' from fetch_price output, and removed inline 'suggestion' fields from several technical_tools returns (clean up response payloads). Misc: minor doc/comment and formatting updates in tool_registry.