### PR TITLE
Add hard-block, dedupe, scorer & tool enhancements

### DIFF
--- a/Src/data_engine/analysis_tools/about_strategy.md
+++ b/Src/data_engine/analysis_tools/about_strategy.md
@@ -96,10 +96,29 @@ Every tool output goes through `ToolResultScorer` before reaching the LLM. The s
 ```
 weighted_score_i  = score_i × weight_i
 avg_score         = Σ(weighted_score_i) / Σ(weight_i)
-should_proceed    = avg_score >= 0.6
+hard_block        = any tool output has is_safe_to_trade == False
+should_proceed    = (avg_score >= 0.6) and not hard_block
 ```
 
 Weights default to `1.0` unless the caller provides a custom weight via `execute_with_scoring(weights={...})`. A weight of `1.5` for `check_upcoming_economic_calendar` means news risk has 50% more influence on the final decision.
+
+**Hard Block mechanism:**
+
+Before evaluating `should_proceed`, the scorer scans every tool output for the field `is_safe_to_trade`. If any tool returns `is_safe_to_trade=False`, a hard block is triggered immediately — the agent must not trade regardless of how high the data quality score is. The block captures the offending tool's `trade_action` and `trade_note` fields into `hard_block_reason` for logging.
+
+This means `should_proceed=False` can now have two distinct causes:
+
+| Cause | `hard_block` | `avg_score` |
+|---|---|---|
+| Data quality too low | `False` | `< 0.6` |
+| Tool explicitly blocked trading | `True` | any value |
+
+`ScoreReport` fields related to this feature:
+
+| Field | Type | Description |
+|---|---|---|
+| `hard_block` | `bool` | `True` if any tool signaled `is_safe_to_trade=False` |
+| `hard_block_reason` | `str` | `"[tool_name] trade_action=... — note"`, empty if no block |
 
 **Score interpretation:**
 
@@ -116,11 +135,27 @@ Weights default to `1.0` unless the caller provides a custom weight via `execute
 
 `execute_with_scoring()` (in `tool_registry.py`) is the main entry point for calling multiple tools as a batch. It runs the following pipeline:
 
-**Round 1:** Call all tools in the `tool_calls` list, wrap each result as `ToolResult`, score the batch.
+**Step 0 — Deduplication:** Before any tool is called, duplicate `(tool_name, params)` pairs in `tool_calls` are removed. This prevents a repeated call from inflating the weighted average score artificially.
 
-**Retry (Rounds 2–N, up to `max_rounds=3`):** If `avg_score < 0.6`, inspect `report.recommendations` and call the recommended supplementary tools. Re-score all accumulated results together.
+**Round 1:** Call all deduplicated tools via `_call_safe()`, wrap each result as `ToolResult`, score the batch.
+
+**Retry (Rounds 2–N, up to `max_rounds=3`):** If `should_proceed=False`, inspect `report.recommendations` and call the recommended supplementary tools. Re-score all accumulated results together.
 
 **Termination:** Loop exits when `should_proceed=True` or when `max_rounds` is exhausted. In the latter case, the agent proceeds with whatever context it has rather than blocking indefinitely.
+
+**`_call_safe()` helper:** An internal function that wraps every tool call with error handling. If the tool raises an exception, it returns a `ToolResult` with `status=error` instead of propagating the exception — keeping the retry loop alive. `KeyError` (tool not found) is re-raised so the loop can skip it cleanly.
+
+**`ScoreReport` fields returned:**
+
+| Field | Type | Description |
+|---|---|---|
+| `tool_scores` | `list[ToolScore]` | Per-tool score and reason |
+| `avg_score` | `float` | Weighted average across all tools |
+| `should_proceed` | `bool` | `True` if `avg_score ≥ 0.6` AND no hard block |
+| `hard_block` | `bool` | `True` if any tool returned `is_safe_to_trade=False` |
+| `hard_block_reason` | `str` | Details of the blocking tool (empty if no block) |
+| `recommendations` | `list[Recommendation]` | Tools to call next (empty if `should_proceed=True`) |
+| `summary` | `str` | One-line log string |
 
 ```python
 # Example call
@@ -133,7 +168,9 @@ report = execute_with_scoring(
     max_rounds=3,
 )
 
-if report.should_proceed:
+if report.hard_block:
+    print(f"Trading blocked: {report.hard_block_reason}")
+elif report.should_proceed:
     llm_context = {ts.tool_name: ts for ts in report.tool_scores}
 else:
     for rec in report.recommendations:
@@ -151,8 +188,7 @@ detect_breakout_confirmation  ──►  get_support_resistance_zones
 check_bb_rsi_combo            ──►  detect_rsi_divergence
                               ──►  calculate_ema_distance
 
-detect_rsi_divergence         ──►  check_bb_rsi_combo
-                              ──►  detect_breakout_confirmation
+detect_rsi_divergence         ──►  calculate_ema_distance
 
 calculate_ema_distance        ──►  get_htf_trend
                               ──►  check_spot_thb_alignment
@@ -167,7 +203,7 @@ check_upcoming_economic_calendar ──►  get_intermarket_correlation
 get_intermarket_correlation   ──►  check_upcoming_economic_calendar
                               ──►  get_deep_news_by_category
 
-get_deep_news_by_category     ──►  (special: retry with next category)
+get_deep_news_by_category     ──►  (special: retry with next untried category)
 ```
 
 `detect_swing_low` and `get_gold_etf_flow` are not in the recommendation graph. They are standalone tools whose low scores do not trigger follow-up calls.
@@ -299,17 +335,35 @@ If the upstream `fetch_news()` returns an error or no articles, the wrapper retu
 
 #### Scoring (ToolResultScorer)
 
-| `count` | Score | Reason |
+The scorer first derives a base score from article count, then blends in `relevance_score` if the tool provides it.
+
+**Base score (count-based):**
+
+| `count` | Base Score | Label |
 |---|---|---|
-| `0` | `0.2` | No articles found |
-| `1–2` | `0.5` | Few articles — weak coverage |
+| `0` | `0.2` | No articles found (floor) |
+| `1–2` | `0.5` | Few articles |
 | `3–4` | `0.7` | Adequate coverage |
 | `5+` | `0.85` | Full coverage |
-| error | `0.0` | Tool failed |
+
+**Relevance blending (if `relevance_score` field present in output):**
+
+```
+final_score = base × 0.6 + relevance_score × 0.4
+```
+
+`relevance_score` is a 0.0–1.0 quality signal provided by the tool itself (e.g. semantic similarity of articles to gold/forex context). Older tool versions that do not emit this field fall back to count-only scoring.
+
+| Condition | Score |
+|---|---|
+| error | `0.0` |
+| `count = 0` | `0.2` |
+| Count-only (no `relevance_score`) | `0.5` / `0.7` / `0.85` |
+| Count + `relevance_score` blended | `min(base × 0.6 + relevance × 0.4, 1.0)` |
 
 #### Recommendation Behavior (Special Case)
 
-Unlike other tools, when `get_deep_news_by_category` scores below `0.6`, the scorer does **not** recommend a different tool. Instead it recommends calling `get_deep_news_by_category` again with the *next* category in the list (cycling through alphabetically). Only one alternative category is recommended per round to avoid flooding the context.
+Unlike other tools, when `get_deep_news_by_category` scores below `0.6`, the scorer does **not** recommend a different tool. Instead it looks through the full `results` history to find all categories that have already been tried across all rounds, then recommends the next untried one. This prevents re-calling a category that already returned few results in a previous round.
 
 #### Example
 
@@ -773,6 +827,8 @@ result = call_tool("detect_swing_low", interval="15m", lookback_candles=20)
 
 Only **bullish** divergence (price lower, momentum higher) is currently implemented. Bearish divergence is not checked.
 
+> **Note on recommendation graph:** In previous versions, a low score on `detect_rsi_divergence` would recommend `check_bb_rsi_combo` and `detect_breakout_confirmation` — creating a circular dependency. This has been fixed. The current map points only to `calculate_ema_distance`.
+
 #### Scoring (ToolResultScorer)
 
 | Condition | Score | Reason |
@@ -961,9 +1017,11 @@ result = call_tool("calculate_ema_distance", interval="15m")
 | Condition | Score | Reason |
 |---|---|---|
 | Clear trend + `|distance| ≥ 1.5%` | `0.75` | HTF trend confirmed with distance |
-| Clear trend + `|distance| < 1.5%` | `0.5` | Trend uncertain — near EMA200 (could consolidate) |
+| Clear trend + `|distance| < 1.5%` | `0.6` | Trend direction clear but near EMA200 — may consolidate |
 | Trend not `"Bullish"` or `"Bearish"` | `0.2` | Unclear trend (floor) |
 | error | `0.0` | Tool failed |
+
+> **Note:** The near-EMA200 case was raised from `0.5` to `0.6` in the latest scorer version. This means `get_htf_trend` now always passes the `PROCEED_THRESHOLD` as long as a valid trend is detected, regardless of how close price is to EMA200.
 
 #### Example
 
@@ -1000,7 +1058,7 @@ result = call_tool("get_htf_trend", timeframe="1h")
 | Tool | Error | No Signal | Signal (weak) | Signal (strong) |
 |---|---|---|---|---|
 | `check_upcoming_economic_calendar` | 0.0 | 0.2 (low) | 0.5 (med) / 0.8 (high) | 1.0 (critical) |
-| `get_deep_news_by_category` | 0.0 | 0.2 | 0.5–0.7 | 0.85 |
+| `get_deep_news_by_category` | 0.0 | 0.2 | 0.5–0.7 (count-only) or blended | 0.85 (or blended) |
 | `get_intermarket_correlation` | 0.0 | 0.2 | 0.3–0.75 | 1.0 |
 | `get_gold_etf_flow` | 0.0 | 0.2 | 0.2 | 0.2 |
 | `check_spot_thb_alignment` | 0.0 | 0.3 | — | 0.85 |
@@ -1010,7 +1068,7 @@ result = call_tool("get_htf_trend", timeframe="1h")
 | `detect_rsi_divergence` | 0.0 | 0.2 | — | 0.85 |
 | `check_bb_rsi_combo` | 0.0 | 0.2 | — | 0.85 |
 | `calculate_ema_distance` | 0.0 | 0.2 | 0.75 | 0.90 |
-| `get_htf_trend` | 0.0 | 0.2 | 0.5 | 0.75 |
+| `get_htf_trend` | 0.0 | 0.2 | 0.6 (near EMA200) | 0.75 |
 
 ### Tools Needing Dedicated Scorers
 

--- a/Src/data_engine/analysis_tools/fundamental_tools.py
+++ b/Src/data_engine/analysis_tools/fundamental_tools.py
@@ -10,6 +10,50 @@ import requests
 logger = logging.getLogger(__name__)
 
 
+# ─── News Relevance Helper ──────────────────────────────────────────────────
+
+# คำสำคัญต่อ category สำหรับตรวจ relevance ของแต่ละบทความ
+_CATEGORY_KEYWORDS: dict[str, list[str]] = {
+    "gold_price":        ["gold", "xau", "bullion", "precious metal", "spot gold"],
+    "usd_thb":           ["usd", "thb", "baht", "dollar", "thai baht", "usd/thb"],
+    "fed_policy":        ["fed", "fomc", "federal reserve", "interest rate", "powell", "rate hike", "rate cut"],
+    "inflation":         ["inflation", "cpi", "pce", "price index", "deflation", "consumer price"],
+    "geopolitics":       ["war", "conflict", "sanction", "geopolitic", "tension", "ukraine", "middle east", "israel"],
+    "dollar_index":      ["dxy", "dollar index", "usd index", "dollar strength", "dollar weakness"],
+    "thai_economy":      ["thailand", "thai economy", "bot", "bank of thailand", "set index", "thai gdp"],
+    "thai_gold_market":  ["ทอง", "ราคาทอง", "สมาคมค้าทองคำ", "gold association", "thai gold"],
+}
+
+
+def _compute_news_relevance(articles: list[dict], category: str) -> float:
+    """
+    คำนวณ relevance_score (0.0–1.0) จากสัดส่วนบทความที่มีคำสำคัญของ category
+
+    Logic:
+        - นับบทความที่ title หรือ summary มีคำสำคัญ ≥ 1 คำ
+        - score = matched / total  (0.0 ถ้าไม่มีบทความ)
+        - ถ้าไม่รู้จัก category → คืน 0.5 เป็น neutral fallback
+    """
+    if not articles:
+        return 0.0
+
+    keywords = _CATEGORY_KEYWORDS.get(category)
+    if not keywords:
+        return 0.5  # category ใหม่ที่ยังไม่มี keywords → neutral
+
+    matched = 0
+    for article in articles:
+        text = " ".join([
+            str(article.get("title", "")),
+            str(article.get("summary", "")),
+            str(article.get("description", "")),
+        ]).lower()
+        if any(kw in text for kw in keywords):
+            matched += 1
+
+    return round(matched / len(articles), 3)
+
+
 def get_deep_news_by_category(category: str) -> dict:
     """
     🔄 WRAPPER: ดึงข่าวเจาะลึกตามหมวดหมู่ (Backward compatible)
@@ -48,11 +92,14 @@ def get_deep_news_by_category(category: str) -> dict:
         # Transform result to maintain backward compatibility
         # ─────────────────────────────────────────────────────────────
         if "deep_news" in result and result.get("error") is None:
+            articles = result["deep_news"].get("articles", [])
+            count    = result["deep_news"].get("count", 0)
             return {
                 "status": "success",
                 "category": category,
-                "articles": result["deep_news"].get("articles", []),
-                "count": result["deep_news"].get("count", 0),
+                "articles": articles,
+                "count": count,
+                "relevance_score": _compute_news_relevance(articles, category),
             }
         elif "deep_news_error" in result:
             return {
@@ -237,10 +284,24 @@ def check_upcoming_economic_calendar(hours_ahead: int = 24) -> dict:
         risk_level, high_usd, high_other, medium_all, hours_ahead
     )
 
+    # ── Step 3b: MAP risk_level → trade guidance ──────────────────
+    _TRADE_GUIDANCE = {
+        "critical": (False, "avoid",   "ห้ามเปิดออเดอร์ใหม่ — ข่าว High Impact ใกล้ออก"),
+        "high":     (False, "reduce",  "ลด position / งด open trade ใหม่"),
+        "medium":   (True,  "caution", "เทรดได้แต่ระวัง volatility"),
+        "low":      (True,  "proceed", "ไม่มีข่าวสำคัญ — เทรดตาม technical ได้เลย"),
+    }
+    is_safe_to_trade, trade_action, trade_note = _TRADE_GUIDANCE.get(
+        risk_level, (True, "proceed", "")
+    )
+
     result = {
         "status": "success",
         "source": "forexfactory_json",
         "risk_level": risk_level,
+        "is_safe_to_trade": is_safe_to_trade,   # False → scorer/orchestrator ควรหยุด
+        "trade_action": trade_action,            # "avoid" | "reduce" | "caution" | "proceed"
+        "trade_note": trade_note,
         "hours_checked": hours_ahead,
         "high_impact_usd_count": len(high_usd),
         "high_impact_other_count": len(high_other),

--- a/Src/data_engine/analysis_tools/technical_tools.py
+++ b/Src/data_engine/analysis_tools/technical_tools.py
@@ -288,16 +288,48 @@ def detect_rsi_divergence(interval: str = "15m", history_days: int = 5, lookback
         
         is_price_lower = low2 < low1
         is_rsi_higher = rsi2 > rsi1
-        divergence_found = bool(is_price_lower and is_rsi_higher)
+        bullish_divergence = bool(is_price_lower and is_rsi_higher)
+
+        # ── Bearish Divergence: ราคาทำ higher high แต่ RSI ทำ lower high ──
+        peaks_idx, _ = find_peaks(recent_df['high'], prominence=atr * 1.0)
+        bearish_divergence = False
+        bearish_data: dict = {}
+        if len(peaks_idx) >= 2:
+            p1 = peaks_idx[-2]
+            p2 = peaks_idx[-1]
+            high1 = recent_df['high'].iloc[p1]
+            hrsi1 = recent_df['rsi_14'].iloc[p1]
+            high2 = recent_df['high'].iloc[p2]
+            hrsi2 = recent_df['rsi_14'].iloc[p2]
+            bearish_divergence = bool(high2 > high1 and hrsi2 < hrsi1)
+            bearish_data = {
+                "High1": round(float(high1), 2), "RSI1": round(float(hrsi1), 2),
+                "High2": round(float(high2), 2), "RSI2": round(float(hrsi2), 2),
+            }
+
+        divergence_found = bullish_divergence or bearish_divergence
+        if bullish_divergence:
+            divergence_type = "bullish"
+            logic = "Price lower but RSI higher (Bullish Divergence)"
+            data = {
+                "Low1": round(float(low1), 2), "RSI1": round(float(rsi1), 2),
+                "Low2": round(float(low2), 2), "RSI2": round(float(rsi2), 2),
+            }
+        elif bearish_divergence:
+            divergence_type = "bearish"
+            logic = "Price higher but RSI lower (Bearish Divergence)"
+            data = bearish_data
+        else:
+            divergence_type = None
+            logic = "Price and RSI aligned (No Divergence)"
+            data = {}
 
         return {
             "status": "success",
             "divergence_detected": divergence_found,
-            "logic": "Price lower but RSI higher (Bullish Divergence)" if divergence_found else "Price and RSI aligned (No Divergence)",
-            "data": {
-                "Low1": round(float(low1), 2), "RSI1": round(float(rsi1), 2),
-                "Low2": round(float(low2), 2), "RSI2": round(float(rsi2), 2)
-            }
+            "divergence_type": divergence_type,   # "bullish" | "bearish" | None
+            "logic": logic,
+            "data": data,
         }
     except Exception as e:
         return {"status": "error", "message": str(e)}
@@ -329,21 +361,44 @@ def check_bb_rsi_combo(interval: str = "15m", history_days: int = 5, ohlcv_df: p
         macd_hist_prev = prev['macd_hist']
         atr = float(latest['atr_14'])
 
-        is_price_low = current_price < lower_bb
+        upper_bb = latest['bb_high']
+
+        # ── Bullish combo: oversold ──
+        is_price_low    = current_price < lower_bb
         is_rsi_oversold = rsi < 35.0
         is_macd_flatten = abs(macd_hist_current) < (atr * 0.05) or (macd_hist_current > macd_hist_prev)
-        
-        combo_met = bool(is_price_low and is_rsi_oversold and is_macd_flatten)
-        
+        bullish_combo   = bool(is_price_low and is_rsi_oversold and is_macd_flatten)
+
+        # ── Bearish combo: overbought ──
+        is_price_high      = current_price > upper_bb
+        is_rsi_overbought  = rsi > 65.0
+        is_macd_flatten_dn = abs(macd_hist_current) < (atr * 0.05) or (macd_hist_current < macd_hist_prev)
+        bearish_combo      = bool(is_price_high and is_rsi_overbought and is_macd_flatten_dn)
+
+        combo_met = bullish_combo or bearish_combo
+        if bullish_combo:
+            combo_direction = "bullish"
+            details = f"Price<LowerBB: {is_price_low}, RSI<35: {is_rsi_oversold}, MACD_Flatten: {is_macd_flatten}"
+        elif bearish_combo:
+            combo_direction = "bearish"
+            details = f"Price>UpperBB: {is_price_high}, RSI>65: {is_rsi_overbought}, MACD_Flatten: {is_macd_flatten_dn}"
+        else:
+            combo_direction = None
+            details = f"Price<BB: {is_price_low}, RSI<35: {is_rsi_oversold}, MACD_Flatten: {is_macd_flatten}"
+
         return {
             "status": "success",
             "interval": interval,
             "combo_detected": combo_met,
+            "combo_direction": combo_direction,   # "bullish" | "bearish" | None
             "raw_data": {
-                "price": round(current_price, 2), "lower_bb": round(lower_bb, 2), 
-                "rsi": round(rsi, 2), "macd_hist": round(macd_hist_current, 2)
+                "price": round(current_price, 2),
+                "lower_bb": round(lower_bb, 2),
+                "upper_bb": round(upper_bb, 2),
+                "rsi": round(rsi, 2),
+                "macd_hist": round(macd_hist_current, 2),
             },
-            "details": f"Price<BB: {is_price_low}, RSI<35: {is_rsi_oversold}, MACD_Flatten: {is_macd_flatten}"
+            "details": details,
         }
     except Exception as e:
         return {"status": "error", "message": str(e)}

--- a/Src/data_engine/tools/tool_registry.py
+++ b/Src/data_engine/tools/tool_registry.py
@@ -141,6 +141,33 @@ def call_tool_as_result(
     )
 
 
+def _call_safe(
+    tool_name: str,
+    params: dict,
+    weight: float,
+) -> ToolResult:
+    """
+    Internal helper: call tool เดียวพร้อม error handling ครบวงจร
+    ใช้แทน try/except ซ้ำๆ ใน execute_with_scoring เพื่อลด code duplication
+
+    คืน ToolResult เสมอ — ถ้า tool crash จะสร้าง ToolResult(status=error)
+    แทนที่จะ raise exception ให้ caller จัดการเอง
+    """
+    try:
+        return call_tool_as_result(tool_name, weight=weight, **params)
+    except KeyError as e:
+        logger.warning(f"[_call_safe] Tool ไม่พบ: {e}")
+        raise   # re-raise KeyError ให้ caller skip ได้ถูกต้อง
+    except Exception as e:
+        logger.error(f"[_call_safe] '{tool_name}' error: {e}")
+        return ToolResult(
+            tool_name=tool_name,
+            output={"status": "error", "message": str(e)},
+            params=params,
+            weight=weight,
+        )
+
+
 def execute_with_scoring(
     tool_calls: list[tuple[str, dict]],
     weights: dict[str, float] | None = None,
@@ -150,11 +177,12 @@ def execute_with_scoring(
     เรียก tools หลายตัวพร้อมกัน → score → loop ถ้าคะแนนไม่ถึง 0.6
 
     Pipeline:
-        1. Call tools ทุกตัวใน tool_calls
-        2. ส่งผลทั้งหมดเข้า ToolResultScorer
-        3. ถ้า avg score < 0.6 → call tools ที่ scorer แนะนำเพิ่ม
-        4. วน loop ซ้ำจนกว่าจะผ่าน หรือครบ max_rounds
-        5. คืน ScoreReport สุดท้าย (should_proceed + tool_scores + recommendations)
+        1. Dedup tool_calls (tool_name, params) เพื่อกัน avg พอง
+        2. Call tools ทุกตัวใน tool_calls
+        3. ส่งผลทั้งหมดเข้า ToolResultScorer
+        4. ถ้า avg score < 0.6 → call tools ที่ scorer แนะนำเพิ่ม
+        5. วน loop ซ้ำจนกว่าจะผ่าน หรือครบ max_rounds
+        6. คืน ScoreReport สุดท้าย (should_proceed + tool_scores + recommendations)
 
     Args:
         tool_calls:  list ของ (tool_name, params_dict) ที่จะ call รอบแรก
@@ -169,48 +197,35 @@ def execute_with_scoring(
             - tool_scores:       คะแนนและเหตุผลของแต่ละ tool
             - avg_score:         weighted average ของทุก tool
             - should_proceed:    True ถ้าพร้อมส่งเข้า LLM
+            - hard_block:        True ถ้า tool บอกว่า is_safe_to_trade=False
+            - hard_block_reason: สาเหตุของ hard_block
             - recommendations:   tool ที่ควร call เพิ่ม (ว่างถ้า should_proceed=True)
             - summary:           สรุปสั้นๆ สำหรับ log
-
-    Example:
-        report = execute_with_scoring(
-            tool_calls=[
-                ("check_upcoming_economic_calendar", {"hours_ahead": 24}),
-                ("detect_breakout_confirmation",     {"zone_top": 3250, "zone_bottom": 3200, "interval": "15m"}),
-                ("get_htf_trend",                   {"timeframe": "1h"}),
-            ],
-            weights={"check_upcoming_economic_calendar": 1.5},
-            max_rounds=3,
-        )
-
-        if report.should_proceed:
-            # รวม outputs ทั้งหมดเพื่อส่งเข้า LLM
-            llm_context = {ts.tool_name: ... for ts in report.tool_scores}
-        else:
-            # ดู recommendations เพื่อตัดสินใจว่าจะ retry หรือ proceed ด้วย context ที่มี
-            for rec in report.recommendations:
-                print(f"แนะนำ call: {rec.recommended_tool} params={rec.suggested_params}")
     """
     weights = weights or {}
 
+    # ── Dedup: กัน (tool_name, params) ซ้ำที่จะทำให้ avg score พองเกินจริง ──
+    seen: set[tuple] = set()
+    deduped: list[tuple[str, dict]] = []
+    for tool_name, params in tool_calls:
+        key = (tool_name, tuple(sorted(params.items())))
+        if key in seen:
+            logger.warning(
+                f"[execute_with_scoring] Duplicate tool_call ถูกข้าม: '{tool_name}' params={params}"
+            )
+            continue
+        seen.add(key)
+        deduped.append((tool_name, params))
+
     # ── Round 1: Call tools ชุดแรก ─────────────────────────────────────────
     results: list[ToolResult] = []
-    for tool_name, params in tool_calls:
+    for tool_name, params in deduped:
         try:
             w = weights.get(tool_name, 1.0)
-            result = call_tool_as_result(tool_name, weight=w, **params)
+            result = _call_safe(tool_name, params, w)
             results.append(result)
-        except KeyError as e:
-            logger.warning(f"[execute_with_scoring] Tool ไม่พบ: {e} — ข้ามไป")
-        except Exception as e:
-            # ถ้า tool crash → สร้าง ToolResult ที่ status=error เพื่อให้ scorer ให้ 0.0
-            logger.error(f"[execute_with_scoring] '{tool_name}' error: {e}")
-            results.append(ToolResult(
-                tool_name=tool_name,
-                output={"status": "error", "message": str(e)},
-                params=params,
-                weight=weights.get(tool_name, 1.0),
-            ))
+        except KeyError:
+            pass  # _call_safe log แล้ว + re-raise KeyError → ข้ามไปเงียบๆ
 
     report = _scorer.score(results)
     logger.info(f"[execute_with_scoring] Round 1 — {report.summary}")
@@ -229,25 +244,21 @@ def execute_with_scoring(
         for rec in report.recommendations:
             try:
                 w = weights.get(rec.recommended_tool, 1.0)
-                new_result = call_tool_as_result(rec.recommended_tool, weight=w, **rec.suggested_params)
+                new_result = _call_safe(rec.recommended_tool, rec.suggested_params, w)
                 results.append(new_result)
                 logger.info(f"[execute_with_scoring] ✅ '{rec.recommended_tool}' called — reason: {rec.reason}")
-            except KeyError as e:
-                logger.warning(f"[execute_with_scoring] Recommended tool ไม่พบ: {e} — ข้ามไป")
-            except Exception as e:
-                logger.error(f"[execute_with_scoring] '{rec.recommended_tool}' error: {e}")
-                results.append(ToolResult(
-                    tool_name=rec.recommended_tool,
-                    output={"status": "error", "message": str(e)},
-                    params=rec.suggested_params,
-                    weight=w,
-                ))
+            except KeyError:
+                pass  # tool ไม่พบ — _call_safe log แล้ว
 
         report = _scorer.score(results)
         logger.info(f"[execute_with_scoring] Round {round_num} — {report.summary}")
 
     # ── Log สรุปผลสุดท้าย ──────────────────────────────────────────────────
-    if report.should_proceed:
+    if report.hard_block:
+        logger.warning(
+            f"[execute_with_scoring] 🚫 HARD BLOCK — {report.hard_block_reason}"
+        )
+    elif report.should_proceed:
         logger.info(
             f"[execute_with_scoring] ✅ PROCEED — avg={report.avg_score:.3f} "
             f"| {len(results)} tools called"

--- a/Src/data_engine/tools/tool_result_scorer.py
+++ b/Src/data_engine/tools/tool_result_scorer.py
@@ -45,7 +45,9 @@ class ScoreReport:
     """ผลลัพธ์รวมของ ToolResultScorer"""
     tool_scores: list[ToolScore]
     avg_score: float
-    should_proceed: bool                                    # True ถ้า avg >= 0.6
+    should_proceed: bool                                    # True ถ้า avg >= 0.6 AND ไม่มี hard_block
+    hard_block: bool                                        # True ถ้ามี tool ส่ง is_safe_to_trade=False
+    hard_block_reason: str                                  # อธิบาย hard_block (ว่างถ้า hard_block=False)
     recommendations: list[Recommendation]                  # ว่างถ้า should_proceed = True
     summary: str                                            # สรุปสั้นๆ สำหรับ log
 
@@ -79,7 +81,7 @@ class ToolResultScorer:
     _RECOMMENDATION_MAP: dict[str, list[str]] = {
         "detect_breakout_confirmation":   ["get_support_resistance_zones", "check_bb_rsi_combo"],
         "check_bb_rsi_combo":             ["detect_rsi_divergence", "calculate_ema_distance"],
-        "detect_rsi_divergence":          ["check_bb_rsi_combo", "detect_breakout_confirmation"],
+        "detect_rsi_divergence":          ["calculate_ema_distance"],          # ลบ check_bb_rsi_combo ออก (circular)
         "calculate_ema_distance":         ["get_htf_trend", "check_spot_thb_alignment"],
         "get_support_resistance_zones":   ["detect_breakout_confirmation"],
         "get_htf_trend":                  ["check_spot_thb_alignment"],
@@ -100,6 +102,8 @@ class ToolResultScorer:
                 tool_scores=[],
                 avg_score=0.0,
                 should_proceed=False,
+                hard_block=False,
+                hard_block_reason="",
                 recommendations=[],
                 summary="ไม่มี tool results ส่งมา",
             )
@@ -122,26 +126,39 @@ class ToolResultScorer:
             sum(ts.weighted_score for ts in tool_scores) / total_weight, 4
         ) if total_weight > 0 else 0.0
 
-        should_proceed = avg_score >= PROCEED_THRESHOLD
+        # ── Hard Block: tool บอกว่า is_safe_to_trade=False → หยุดทันที ──────
+        # ตรวจก่อน should_proceed เสมอ เพราะ data quality สูง ≠ ควรเทรด
+        hard_block = False
+        hard_block_reason = ""
+        for tr in results:
+            if tr.output.get("is_safe_to_trade") is False:
+                hard_block = True
+                action = tr.output.get("trade_action", "avoid")
+                note   = tr.output.get("trade_note", "")
+                hard_block_reason = (
+                    f"[{tr.tool_name}] trade_action={action}"
+                    + (f" — {note}" if note else "")
+                )
+                break
+
+        should_proceed = (avg_score >= PROCEED_THRESHOLD) and not hard_block
 
         recommendations: list[Recommendation] = []
         if not should_proceed:
-            already_called = {tr.tool_name for tr in results}
             for tr, ts in zip(results, tool_scores):
                 if ts.score < PROCEED_THRESHOLD:
-                    recs = self._build_recommendations(tr, already_called)
+                    recs = self._build_recommendations(tr, results)   # ← ส่ง results ทั้งหมด
                     recommendations.extend(recs)
-                    # เพิ่ม recommended tools เข้า already_called เพื่อกัน duplicate
-                    for r in recs:
-                        already_called.add(r.recommended_tool)
 
-        summary = self._build_summary(tool_scores, avg_score, should_proceed)
+        summary = self._build_summary(tool_scores, avg_score, should_proceed, hard_block)
         logger.info(f"[ToolResultScorer] {summary}")
 
         return ScoreReport(
             tool_scores=tool_scores,
             avg_score=avg_score,
             should_proceed=should_proceed,
+            hard_block=hard_block,
+            hard_block_reason=hard_block_reason,
             recommendations=recommendations,
             summary=summary,
         )
@@ -285,7 +302,7 @@ class ToolResultScorer:
 
         if distance_pct >= 1.5:
             return 0.75, f"HTF trend {trend} | ห่าง EMA200 {distance_pct:.2f}% — ชัดเจน"
-        return 0.5, f"HTF trend {trend} แต่ใกล้ EMA200 ({distance_pct:.2f}%) — อาจ consolidate"
+        return 0.6, f"HTF trend {trend} ใกล้ EMA200 ({distance_pct:.2f}%) — อาจ consolidate แต่ทิศชัด"
 
     def _score_spot_thb_alignment(self, output: dict) -> tuple[float, str]:
         if output.get("status") == "error":
@@ -321,14 +338,34 @@ class ToolResultScorer:
         if output.get("status") == "error":
             return 0.0, f"Error: {output.get('message')}"
 
-        count = output.get("count", 0)
+        count           = output.get("count", 0)
+        relevance_score = output.get("relevance_score")   # 0.0–1.0 จาก tool (อาจไม่มีถ้า tool เก่า)
+
         if count == 0:
             return FLOOR_SCORE, "ไม่พบบทความเลย"
+
+        # base score จาก count
         if count <= 2:
-            return 0.5, f"พบ {count} บทความ — น้อย"
-        if count <= 4:
-            return 0.7, f"พบ {count} บทความ — พอใช้"
-        return 0.85, f"พบ {count} บทความ — ครบถ้วน"
+            base = 0.5
+            count_label = f"พบ {count} บทความ — น้อย"
+        elif count <= 4:
+            base = 0.7
+            count_label = f"พบ {count} บทความ — พอใช้"
+        else:
+            base = 0.85
+            count_label = f"พบ {count} บทความ — ครบถ้วน"
+
+        # ถ้ามี relevance_score → ปรับ base ตาม quality จริง
+        if relevance_score is not None:
+            # weighted blend: 60% count-based + 40% relevance
+            blended = round(base * 0.6 + relevance_score * 0.4, 4)
+            reason = (
+                f"{count_label} | relevance={relevance_score:.2f} → score={blended:.2f}"
+            )
+            return min(blended, 1.0), reason
+
+        # fallback ถ้าไม่มี relevance_score (tool เก่า)
+        return base, count_label
 
     def _score_intermarket_correlation(self, output: dict) -> tuple[float, str]:
         if output.get("status") == "error":
@@ -355,26 +392,33 @@ class ToolResultScorer:
     def _build_recommendations(
         self,
         tr: ToolResult,
-        already_called: set[str],
+        results: list[ToolResult],          # ← รับ results แทน already_called set
     ) -> list[Recommendation]:
         recs: list[Recommendation] = []
 
-        # กรณีพิเศษ: get_deep_news_by_category → แนะนำ retry ด้วย category อื่น
+        # ── already_called: tool_name ระดับทั่วไป (ไม่นับ params) ───────────
+        already_called: set[str] = {r.tool_name for r in results}
+
+        # กรณีพิเศษ: get_deep_news_by_category → track ระดับ category (params)
         if tr.tool_name == "get_deep_news_by_category":
-            current_category = tr.params.get("category", "")
+            tried_categories: set[str] = {
+                r.params.get("category", "")
+                for r in results
+                if r.tool_name == "get_deep_news_by_category"
+            }
             all_categories = [
                 "gold_price", "usd_thb", "fed_policy", "inflation",
                 "geopolitics", "dollar_index", "thai_economy", "thai_gold_market",
             ]
             for cat in all_categories:
-                if cat != current_category:
+                if cat not in tried_categories:
                     recs.append(Recommendation(
                         source_tool=tr.tool_name,
                         recommended_tool="get_deep_news_by_category",
                         suggested_params={"category": cat},
-                        reason=f"ข่าว category '{current_category}' ไม่เพียงพอ → ลอง '{cat}'",
+                        reason=f"ลอง category ถัดไปที่ยังไม่ได้ call: '{cat}'",
                     ))
-                    break   # แนะนำแค่ category ถัดไป 1 อัน ไม่ flood
+                    break   # แนะนำครั้งละ 1 category ไม่ flood
             return recs
 
         # กรณีทั่วไป
@@ -383,7 +427,6 @@ class ToolResultScorer:
             if suggested in already_called:
                 continue
 
-            # สืบทอด params ที่ compatible (interval, history_days)
             inherited_params: dict[str, Any] = {}
             for key in ("interval", "history_days", "timeframe"):
                 if key in tr.params:
@@ -395,6 +438,7 @@ class ToolResultScorer:
                 suggested_params=inherited_params,
                 reason=f"'{tr.tool_name}' score ต่ำ → เพิ่มข้อมูลด้วย '{suggested}'",
             ))
+            already_called.add(suggested)   # กัน duplicate ภายใน loop นี้
 
         return recs
 
@@ -405,8 +449,14 @@ class ToolResultScorer:
         tool_scores: list[ToolScore],
         avg_score: float,
         should_proceed: bool,
+        hard_block: bool = False,
     ) -> str:
-        status = "✅ PROCEED" if should_proceed else "🔄 NEED MORE TOOLS"
+        if hard_block:
+            status = "🚫 HARD BLOCK"
+        elif should_proceed:
+            status = "✅ PROCEED"
+        else:
+            status = "🔄 NEED MORE TOOLS"
         scores_str = " | ".join(
             f"{ts.tool_name}={ts.score:.2f}(x{ts.weight})" for ts in tool_scores
         )


### PR DESCRIPTION
Introduce a hard-block mechanism and several robustness/quality improvements across the toolchain. Key changes:

- ToolResultScorer: add hard_block and hard_block_reason to ScoreReport; hard_block prevents proceeding even if avg_score is high. Remove circular recommendation for detect_rsi_divergence and bump near-EMA HTF score from 0.5→0.6. Blend a tool-provided relevance_score into news scoring.
- execute_with_scoring / tool_registry: add _call_safe helper to catch tool exceptions and return ToolResult(status=error) instead of crashing. Deduplicate identical (tool_name, params) calls before execution, use _call_safe throughout, and log hard-blocks and duplicate skips.
- fundamental_tools.get_deep_news_by_category: compute and return relevance_score (based on category keywords) and update recommendation behavior to prefer the next untried category across all rounds. check_upcoming_economic_calendar now maps risk_level→is_safe_to_trade/trade_action/trade_note for hard-block signaling.
- technical_tools: detect_rsi_divergence now detects bullish and bearish divergences and returns divergence_type and data; check_bb_rsi_combo recognizes both bullish and bearish combos and returns combo_direction and richer raw_data/details.

These changes improve safety (explicit tool-driven trade blocks), resilience (no crashes from tool failures), recommendation quality (dedupe and smarter retries), and scoring fidelity (news relevance blending and adjusted HTF scoring).