### PR TITLE
feat: enforce manual-only SELL — remove all auto-exit paths

### DIFF
--- a/Src_V4/core/dynamic_tp_manager.py
+++ b/Src_V4/core/dynamic_tp_manager.py
@@ -14,13 +14,15 @@ class DynamicTPManager:
         atr_multiplier: float = 1.5,
         breakeven_atr_mult: float = 1.0,
         score_drop_threshold: float = 0.15,
-        be_floor_offset: float = 2.0
+        be_floor_offset: float = 2.0,
+        recovery_score_margin: float = 0.10,
     ):
         self.atr_mult = atr_multiplier
         self.be_mult = breakeven_atr_mult
         self.score_drop_thresh = score_drop_threshold
         self.be_floor_offset = be_floor_offset
-        
+        self.recovery_score_margin = recovery_score_margin
+
         self.is_active = False
         self.entry_ask: Optional[float] = None
         self.entry_score: Optional[float] = None
@@ -94,6 +96,14 @@ class DynamicTPManager:
 
         # 📈 Priority 5: Normal
         return "TP_UPDATED", active_trail, active_trail
+
+    # ── Pending-sell recovery helpers ────────────────────────────────────────
+
+    def should_cancel_pending_sell(self, current_score: float) -> bool:
+        """Return True if the model score has recovered enough to cancel a pending SL exit."""
+        if self.entry_score is None:
+            return False
+        return current_score >= (self.entry_score - self.recovery_score_margin)
 
     # ── Restart persistence ───────────────────────────────────────────────────
 

--- a/Src_V4/notifier/discord_notifier.py
+++ b/Src_V4/notifier/discord_notifier.py
@@ -147,6 +147,22 @@ def notify_buy_confirmed(signal_id: str, price: float, note: str = "") -> None:
     )
 
 
+def notify_sl_recovered(
+    bar_time: str,
+    signal_id: str,
+    score: float,
+    bid: float,
+) -> None:
+    """Pending SL exit cancelled because model score bounced back."""
+    send_discord(
+        f"✅ **SL RECOVERED** — `{bar_time}`\n"
+        f"```\nSignal ID   : {signal_id}\n"
+        f"Score       : {score:.4f}  ← momentum returned\n"
+        f"HSH Bid     : {bid:,.2f} THB\n```\n"
+        f"Pending SELL cancelled — ยังถือต่อ"
+    )
+
+
 def notify_sell_confirmed(
     price: float,
     reason: str = "MANUAL_SELL",

--- a/Src_V4/scheduler/orchestrator.py
+++ b/Src_V4/scheduler/orchestrator.py
@@ -28,6 +28,7 @@ from db.supabase_writer import (
     insert_bar_log,
     get_open_trade,
     get_latest_pending_sell_signal,
+    mark_signal_execution,
 )
 from notifier.discord_notifier import (
     notify_buy_signal,
@@ -35,6 +36,7 @@ from notifier.discord_notifier import (
     notify_heartbeat,
     notify_error,
     notify_dynamic_tp,
+    notify_sl_recovered,
 )
 from notifier.trade_log_api import send_trade_log
 from rationale.generator import build_trade_payload
@@ -192,6 +194,35 @@ def run_signal_pipeline() -> None:
                     f"status={existing_pending_sell.get('execution_status')}) — "
                     f"TP eval and new SELL signals suppressed this bar."
                 )
+
+        # ── SL Recovery: score bounce check ──────────────────────────────────
+        # Runs only when a FORCED pending SELL (SL_HIT or TRAIL_HIT) is waiting.
+        # If model score recovers above entry_score - margin → cancel pending, hold on.
+        # All actual exits require user confirmation via the web UI.
+        if (
+            existing_pending_sell is not None
+            and current_state == STATE_HOLDING
+            and tp_manager.is_active
+        ):
+            pending_trigger = existing_pending_sell.get("reject_reason", "")
+            if pending_trigger in ("FORCED_BY_SL_HIT", "FORCED_BY_TRAIL_HIT"):
+                current_score = inference_result["ranker_score"]
+                current_bid   = features_row["hsh_close_bid"]
+                pending_id    = existing_pending_sell.get("id", "UNKNOWN")
+
+                if tp_manager.should_cancel_pending_sell(current_score):
+                    trading_log.info(
+                        f"[SL Recovery] ✅ Score recovered to {current_score:.4f} — "
+                        f"cancelling pending SELL {pending_id}"
+                    )
+                    mark_signal_execution(
+                        pending_id, "CANCELLED",
+                        note=f"Score recovered to {current_score:.4f}",
+                    )
+                    notify_sl_recovered(
+                        features_row["bar_time"], pending_id, current_score, current_bid
+                    )
+                    existing_pending_sell = None  # allow normal pipeline to continue
 
         tp_trigger, tp_price, trail_level = "NONE", None, 0.0
 

--- a/Src_V4/test_tp_manager.py
+++ b/Src_V4/test_tp_manager.py
@@ -140,6 +140,28 @@ def test_sl_hit():
     assert trigger == "SL_HIT", f"Expected SL_HIT, got {trigger}"
     assert price == 29900.0
 
+# ─── SL Recovery Scenarios ───────────────────────────────────────────────────
+
+def test_sl_recovery_score_bounced():
+    """Bar after SL: score bounces back above entry_score - 0.10 → cancel pending SELL."""
+    tp = DynamicTPManager(recovery_score_margin=0.10)
+    tp.activate(30000.0, entry_score=0.50, initial_bid=30000.0, sl_price=29900.0)
+    tp.update(current_bid=29850.0, atr_48=100.0, current_score=0.30)  # SL_HIT bar
+
+    # Next bar: score recovers to 0.43 (>= 0.50 - 0.10 = 0.40)
+    assert tp.should_cancel_pending_sell(0.43) is True,  "score=0.43 should cancel"
+    assert tp.should_cancel_pending_sell(0.40) is True,  "score=0.40 (boundary) should cancel"
+    assert tp.should_cancel_pending_sell(0.39) is False, "score=0.39 should NOT cancel"
+
+def test_sl_recovery_score_still_low():
+    """Bar after SL: score stays below threshold → do not cancel, keep pending."""
+    tp = DynamicTPManager(recovery_score_margin=0.10)
+    tp.activate(30000.0, entry_score=0.50, initial_bid=30000.0, sl_price=29900.0)
+    tp.update(current_bid=29850.0, atr_48=100.0, current_score=0.20)  # SL_HIT bar
+
+    # Next bar: score is 0.25 — still well below 0.40 threshold
+    assert tp.should_cancel_pending_sell(0.25) is False, "score=0.25 should NOT cancel"
+
 # ─── Main Runner ──────────────────────────────────────────────────────────────
 if __name__ == "__main__":
     print("=" * 55)
@@ -158,6 +180,9 @@ if __name__ == "__main__":
         test_invalid_atr_returns_none,
         test_trigger_priority_trail_vs_score,
         test_sl_hit,
+        # SL recovery
+        test_sl_recovery_score_bounced,
+        test_sl_recovery_score_still_low,
     ]
 
     for test in test_list:


### PR DESCRIPTION
Remove hard-drop auto-confirm logic so every SELL (SL_HIT, TRAIL_HIT, gate SELL) requires explicit user confirmation via the web UI.

- dynamic_tp_manager: drop hard_drop_atr_mult, sl_trigger_bid, is_hard_drop()
- orchestrator: remove hard-drop auto-close block; keep score-recovery cancel only
- discord_notifier: remove notify_sl_hard_drop (no longer triggered)
- test_tp_manager: remove hard-drop tests; add SL recovery score tests