### PR TITLE
feat(Src_V4): add BUY reminder — resend signal at T+30s and T+40s if …

### DIFF
--- a/Src_V4/notifier/discord_notifier.py
+++ b/Src_V4/notifier/discord_notifier.py
@@ -57,6 +57,31 @@ def notify_buy_signal(gate_result: dict, rationale_payload: Optional[dict] = Non
         msg += f"📊 **Rationale:** {rationale_payload['rationale_text']}"
     send_discord(msg)
 
+def notify_buy_reminder(gate_result: dict, reminder_num: int) -> None:
+    """BUY reminder ส่งซ้ำเมื่อยังไม่ได้ confirm — ราคาจาก bar เดิม"""
+    mention = f"<@{DISCORD_MENTION_ID}> " if DISCORD_MENTION_ID else ""
+    atr_usd = gate_result.get("atr_48", 0) or 0
+    usd_thb = gate_result.get("usd_close", 0) or 0
+    atr_thb = convert_atr_usd_to_thb(atr_usd, usd_thb)
+    ask     = gate_result.get("hsh_ask", 0) or 0
+    bid     = gate_result.get("hsh_bid", 0) or 0
+    tp_ref  = ask + atr_thb * TP_ATR_MULTIPLIER
+    sl_ref  = ask - atr_thb * TP_SL_ATR_MULT
+    msg = (
+        f"{mention}\n🔔 **BUY REMINDER #{reminder_num}/2** — `{gate_result['bar_time']}`\n```\n"
+        f"Session     : {gate_result['session']}\n"
+        f"Score       : {gate_result['ranker_score']:.4f}\n"
+        f"HSH Ask     : {ask:,.2f} THB  ← ราคาซื้อ (bar เดิม)\n"
+        f"HSH Bid     : {bid:,.2f} THB\n"
+        f"XAU/USD     : {gate_result.get('xau_close', 0):.2f}\n"
+        f"ATR(48)     : {atr_usd:.2f} USD/oz → {atr_thb:.2f} THB\n"
+        f"TP แนะนำ    : {tp_ref:,.2f} ({TP_ATR_MULTIPLIER}× ATR)\n"
+        f"SL แนะนำ    : {sl_ref:,.2f} ({TP_SL_ATR_MULT}× ATR)\n```\n"
+        f"⚠️ **ยังไม่ได้ Confirm** — กด Confirm BUY ใน UI ก่อนราคาเปลี่ยน | Reminder {reminder_num}/2\n"
+    )
+    send_discord(msg)
+
+
 def notify_sell_signal(gate_result: dict, rationale_payload: Optional[dict] = None) -> None:
     mention = f"<@{DISCORD_MENTION_ID}> " if DISCORD_MENTION_ID else ""
     bid     = gate_result.get("hsh_bid", 0) or 0

--- a/Src_V4/scheduler/orchestrator.py
+++ b/Src_V4/scheduler/orchestrator.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import time
 import uuid
 from datetime import datetime
@@ -38,6 +39,7 @@ from db.supabase_writer import (
 )
 from notifier.discord_notifier import (
     notify_buy_signal,
+    notify_buy_reminder,
     notify_sell_pending,
     notify_heartbeat,
     notify_error,
@@ -60,6 +62,52 @@ trading_log = logging.getLogger("trading")
 _last_bar_time: str = "N/A"
 _last_score: float = 0.0
 _last_state: str = STATE_EMPTY
+
+# BUY reminder: cancel event for the currently-running reminder thread
+_buy_reminder_cancel: threading.Event | None = None
+
+def _run_buy_reminders(gate_result: dict, cancel: threading.Event) -> None:
+    """Background thread: ส่ง BUY reminder ที่ T+30s และ T+40s ถ้ายังไม่ได้ confirm"""
+    # T+30s — Reminder #1
+    if cancel.wait(30):
+        return
+    try:
+        if get_current_state() != STATE_HOLDING:
+            notify_buy_reminder(gate_result, reminder_num=1)
+            trading_log.info("[BUY Reminder] #1 sent — still WAITING_CONFIRM at T+30s")
+        else:
+            trading_log.info("[BUY Reminder] #1 skipped — already HOLDING at T+30s")
+    except Exception as e:
+        trading_log.warning(f"[BUY Reminder] #1 error: {e}")
+
+    # T+40s — Reminder #2
+    if cancel.wait(10):
+        return
+    try:
+        if get_current_state() != STATE_HOLDING:
+            notify_buy_reminder(gate_result, reminder_num=2)
+            trading_log.info("[BUY Reminder] #2 sent — still WAITING_CONFIRM at T+40s")
+        else:
+            trading_log.info("[BUY Reminder] #2 skipped — already HOLDING at T+40s")
+    except Exception as e:
+        trading_log.warning(f"[BUY Reminder] #2 error: {e}")
+
+
+def schedule_buy_reminders(gate_result: dict) -> None:
+    """ยิง background thread สำหรับ BUY reminder — cancel thread เก่าก่อนถ้ามีอยู่"""
+    global _buy_reminder_cancel
+    if _buy_reminder_cancel is not None:
+        _buy_reminder_cancel.set()
+    cancel = threading.Event()
+    _buy_reminder_cancel = cancel
+    t = threading.Thread(
+        target=_run_buy_reminders,
+        args=(gate_result, cancel),
+        daemon=True,
+        name="buy-reminder",
+    )
+    t.start()
+
 
 tp_manager = DynamicTPManager(
     atr_multiplier=TP_ATR_MULTIPLIER,
@@ -656,6 +704,7 @@ def run_signal_pipeline() -> None:
                 trading_log.info(
                     f"BUY signal sent — WAITING_CONFIRM | score={_last_score:.4f} | signal_id={signal_id}"
                 )
+                schedule_buy_reminders(gate_result)
 
             elif signal_type == "SELL":
                 # Manual-confirm mode: do NOT close active trade or flip state here.


### PR DESCRIPTION
…unconfirmed

After a BUY signal fires, a daemon thread sends up to 2 Discord reminders (at T+30s and T+40s) so the user can act before the price drifts. Reminders are skipped if the state flips to HOLDING (user confirmed), and the thread is cancelled automatically when a new BUY signal fires.